### PR TITLE
add multi-account creance view, banking-style loader, and color unifo…

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -690,8 +690,9 @@ function initMenuVisibility() {
         }
     }
     
-    // Menu Montant Début de Mois pour DG, PCA, Admin uniquement
-    if (['directeur_general', 'pca', 'admin'].includes(currentUser.role)) {
+    // Menu Montant Début de Mois — caché à la demande (entrée obsolète, gardée
+    // dans le HTML pour ne rien casser mais plus exposée dans la sidebar).
+    if (false /* ['directeur_general', 'pca', 'admin'].includes(currentUser.role) */) {
         const montantDebutMoisMenu = document.getElementById('montant-debut-mois-menu');
         if (montantDebutMoisMenu) {
             montantDebutMoisMenu.style.display = 'block';
@@ -814,6 +815,14 @@ async function loadInitialData() {
         initAIAnalysis();
         console.log('✅ CLIENT: AI Analysis module initialized');
     }
+
+    // Révéler la sidebar maintenant que toutes les permissions
+    // ont été appliquées (évite le "saut" visible quand des menus
+    // apparaissent/disparaissent en fonction du rôle).
+    // requestAnimationFrame pour s'assurer que le rendu reflète l'état final.
+    requestAnimationFrame(() => {
+        document.body.classList.add('nav-ready');
+    });
 }
 
 // Initialiser le menu collapse
@@ -4446,11 +4455,16 @@ document.addEventListener('DOMContentLoaded', function() {
             currentUser = user;
             await showApp();
             await loadInitialData();
+            // loadInitialData() ajoute lui-même nav-ready (qui cache le loader)
         })
         .catch((error) => {
             // Erreur normale au démarrage si non connecté
             console.log('Utilisateur non connecté, affichage de la page de connexion');
             showLogin();
+            // Pas de loadInitialData en mode non-connecté → on retire le loader nous-même
+            requestAnimationFrame(() => {
+                document.body.classList.add('nav-ready');
+            });
         });
     
     // Gestionnaire de formulaire de connexion
@@ -10647,11 +10661,14 @@ async function initStockModule() {
     }
     
     try {
-        // Default to today's date to avoid loading the entire table
+        // Par défaut : la date d'hier (les données du stock du soir
+        // sont normalement saisies le lendemain matin, hier est la
+        // valeur la plus pertinente à afficher au chargement).
         const dateFilter = document.getElementById('stock-date-filter');
         if (dateFilter && !dateFilter.value) {
-            const today = new Date().toLocaleDateString('en-CA'); // YYYY-MM-DD
-            dateFilter.value = today;
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            dateFilter.value = yesterday.toLocaleDateString('en-CA'); // YYYY-MM-DD
         }
 
         console.log('🏭 CLIENT: Chargement des données...');
@@ -15064,21 +15081,25 @@ function setupBraceHighlightCleanup(configType) {
 let currentCreanceAccount = null;
 
 // Charger les comptes créance au démarrage
+// Cache local des comptes créance pour le mode multi-comptes
+let creanceAccountsCache = [];
+
 async function loadCreanceAccounts() {
     try {
         const response = await fetch(apiUrl('/api/creance/accounts'));
         if (!response.ok) {
             throw new Error(`Erreur ${response.status}: ${response.statusText}`);
         }
-        
+
         const accounts = await response.json();
+        creanceAccountsCache = accounts;
+
         const select = document.getElementById('creance-account-select');
-        
         if (!select) return;
-        
+
         // Vider les options existantes
         select.innerHTML = '<option value="">Choisir un compte créance...</option>';
-        
+
         // Ajouter les comptes
         accounts.forEach(account => {
             const option = document.createElement('option');
@@ -15087,17 +15108,610 @@ async function loadCreanceAccounts() {
             option.dataset.director = account.assigned_director_name || 'Non assigné';
             select.appendChild(option);
         });
-        
+
+        // Peupler aussi les checkboxes du mode multi-comptes
+        renderCreanceMultiCheckboxes(accounts);
+
         // Si il n'y a qu'un seul compte, le sélectionner automatiquement
         if (accounts.length === 1) {
             select.value = accounts[0].id;
-            // Déclencher l'événement de sélection pour charger les données du compte
             handleCreanceAccountSelection();
         }
-        
+
+        // Attacher les event listeners du mode multi (idempotent)
+        setupCreanceMultiModeListeners();
+
     } catch (error) {
         console.error('Erreur chargement comptes créance:', error);
         showNotification('Erreur lors du chargement des comptes créance', 'error');
+    }
+}
+
+// =====================================================
+// MODE MULTI-COMPTES — Vue lecture seule en accordéons
+// =====================================================
+
+function renderCreanceMultiCheckboxes(accounts) {
+    const container = document.getElementById('creance-accounts-checkboxes');
+    if (!container) return;
+    container.innerHTML = '';
+    accounts.forEach(account => {
+        const label = document.createElement('label');
+        label.className = 'checkbox-label';
+        label.style.cssText = 'display: inline-flex; align-items: center; gap: 6px; font-weight: 400;';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'creance-account-checkbox';
+        cb.dataset.accountId = account.id;
+        cb.dataset.accountName = account.account_name;
+        cb.dataset.director = account.assigned_director_name || 'Non assigné';
+        const span = document.createElement('span');
+        span.textContent = account.account_name;
+        label.appendChild(cb);
+        label.appendChild(span);
+        container.appendChild(label);
+
+        cb.addEventListener('change', renderCreanceMultiView);
+    });
+}
+
+function setupCreanceMultiModeListeners() {
+    const toggle = document.getElementById('creance-multi-mode-toggle');
+    const selectAll = document.getElementById('creance-select-all-accounts');
+    const controls = document.getElementById('creance-multi-controls');
+    const multiView = document.getElementById('creance-multi-view');
+    const singleSelect = document.getElementById('creance-account-select');
+    const singleContent = document.getElementById('creance-main-content');
+
+    if (!toggle || toggle.dataset.listenerAttached) return;
+
+    toggle.addEventListener('change', () => {
+        const isMulti = toggle.checked;
+        if (controls) controls.style.display = isMulti ? 'block' : 'none';
+        if (multiView) multiView.style.display = isMulti ? 'block' : 'none';
+        if (singleSelect) singleSelect.parentElement.style.display = isMulti ? 'none' : 'block';
+        if (singleContent && isMulti) singleContent.style.display = 'none';
+        if (isMulti) renderCreanceMultiView();
+    });
+
+    if (selectAll && !selectAll.dataset.listenerAttached) {
+        selectAll.addEventListener('change', () => {
+            document.querySelectorAll('.creance-account-checkbox').forEach(cb => {
+                cb.checked = selectAll.checked;
+            });
+            renderCreanceMultiView();
+        });
+        selectAll.dataset.listenerAttached = 'true';
+    }
+
+    toggle.dataset.listenerAttached = 'true';
+}
+
+async function renderCreanceMultiView() {
+    const container = document.getElementById('creance-multi-view');
+    if (!container) return;
+    const checked = Array.from(document.querySelectorAll('.creance-account-checkbox:checked'));
+    if (checked.length === 0) {
+        container.innerHTML = `
+            <div class="empty-state">
+                <div class="empty-state-icon"><i class="fas fa-check-square"></i></div>
+                <h4>Aucun compte sélectionné</h4>
+                <p>Cochez un ou plusieurs comptes créance ci-dessus pour afficher leurs détails.</p>
+            </div>`;
+        return;
+    }
+
+    // Render un accordéon par compte (tous fermés)
+    container.innerHTML = checked.map(cb => {
+        const accountId = cb.dataset.accountId;
+        const accountName = escapeHtml(cb.dataset.accountName);
+        const director = escapeHtml(cb.dataset.director || 'Non assigné');
+        return `
+            <div class="section-card" data-creance-account-id="${accountId}" style="margin-bottom: 14px;">
+                <button type="button" class="accordion-header collapsed" aria-expanded="false">
+                    <span><i class="fas fa-folder"></i> ${accountName}
+                        <small style="margin-left: 8px; font-weight: 400; opacity: 0.8;">
+                            Directeur : ${director}
+                        </small>
+                    </span>
+                    <i class="fas fa-chevron-down accordion-icon"></i>
+                </button>
+                <div class="accordion-content collapsed" data-creance-content="${accountId}">
+                    <div class="creance-multi-loading">
+                        <span class="qw-loading-inline"><i class="fas fa-spinner fa-spin"></i> Chargement…</span>
+                    </div>
+                </div>
+            </div>`;
+    }).join('');
+
+    // Attacher handlers d'ouverture + bouton "Gérer ce compte"
+    container.querySelectorAll('.accordion-header').forEach(header => {
+        header.addEventListener('click', async () => {
+            const card = header.closest('.section-card');
+            const content = card.querySelector('.accordion-content');
+            const accountId = card.dataset.creanceAccountId;
+            const isCollapsed = header.classList.contains('collapsed');
+            if (isCollapsed) {
+                header.classList.remove('collapsed');
+                content.classList.remove('collapsed');
+                header.setAttribute('aria-expanded', 'true');
+                // Charger les données la première fois
+                if (!content.dataset.loaded) {
+                    await loadCreanceMultiAccountData(accountId, content);
+                    content.dataset.loaded = 'true';
+                }
+            } else {
+                header.classList.add('collapsed');
+                content.classList.add('collapsed');
+                header.setAttribute('aria-expanded', 'false');
+            }
+        });
+    });
+}
+
+/**
+ * Charge le récap clients + l'historique pour un compte donné et les rend
+ * dans le conteneur fourni (pour le mode multi-comptes en lecture seule).
+ */
+async function loadCreanceMultiAccountData(accountId, container) {
+    try {
+        const [clientsRes, opsRes] = await Promise.all([
+            fetch(apiUrl(`/api/creance/${accountId}/clients`)),
+            fetch(apiUrl(`/api/creance/${accountId}/operations`))
+        ]);
+        if (!clientsRes.ok || !opsRes.ok) throw new Error('Erreur chargement données');
+        const clients = await clientsRes.json();
+        const operations = await opsRes.json();
+
+        const fmt = n => (parseFloat(n) || 0).toLocaleString('fr-FR') + ' FCFA';
+        // L'endpoint /api/creance/:accountId/clients renvoie : client_name,
+        // initial_credit, total_credits, total_debits, balance
+        const totalSolde = clients.reduce((s, c) => s + (parseFloat(c.balance) || 0), 0);
+        const recentOps = operations.slice(0, 10);
+
+        container.innerHTML = `
+            <div style="display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+                        padding: 8px 0 16px; border-bottom: 1px solid var(--qw-border);
+                        margin-bottom: 16px;">
+                <div>
+                    <div style="font-size: 12px; color: var(--qw-text-secondary); text-transform: uppercase; letter-spacing: 0.4px;">Solde total</div>
+                    <div style="font-size: 20px; font-weight: 700; color: var(--qw-text);">${fmt(totalSolde)}</div>
+                </div>
+                <div>
+                    <div style="font-size: 12px; color: var(--qw-text-secondary); text-transform: uppercase; letter-spacing: 0.4px;">Clients</div>
+                    <div style="font-size: 16px; font-weight: 600; color: var(--qw-text);">${clients.length}</div>
+                </div>
+                <div>
+                    <div style="font-size: 12px; color: var(--qw-text-secondary); text-transform: uppercase; letter-spacing: 0.4px;">Opérations</div>
+                    <div style="font-size: 16px; font-weight: 600; color: var(--qw-text);">${operations.length}</div>
+                </div>
+                <button type="button" class="btn btn-secondary btn-sm" style="margin-left: auto;"
+                        onclick="switchToSingleCreanceMode(${accountId})">
+                    <i class="fas fa-pen"></i> Gérer ce compte
+                </button>
+            </div>
+
+            <h5 style="font-size: 13px; text-transform: uppercase; letter-spacing: 0.4px;
+                       color: var(--qw-text-secondary); margin: 0 0 8px;">
+                Récapitulatif par client
+            </h5>
+            <div class="table-container" style="margin-bottom: 20px;">
+                <table class="data-table" style="font-size: 13px;">
+                    <thead>
+                        <tr>
+                            <th>Client</th>
+                            <th>Crédit initial</th>
+                            <th>Avances</th>
+                            <th>Remboursements</th>
+                            <th>Solde</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${clients.length === 0 ? `
+                            <tr><td colspan="5" style="text-align: center; color: var(--qw-text-secondary);">Aucun client</td></tr>
+                        ` : clients.map(c => `
+                            <tr>
+                                <td>${escapeHtml(c.client_name)}</td>
+                                <td>${fmt(c.initial_credit)}</td>
+                                <td>${fmt(c.total_credits)}</td>
+                                <td>${fmt(c.total_debits)}</td>
+                                <td><strong>${fmt(c.balance)}</strong></td>
+                            </tr>
+                        `).join('')}
+                    </tbody>
+                </table>
+            </div>
+
+            <h5 style="font-size: 13px; text-transform: uppercase; letter-spacing: 0.4px;
+                       color: var(--qw-text-secondary); margin: 0 0 8px;">
+                Historique récent (10 dernières opérations)
+            </h5>
+            <div class="table-container">
+                <table class="data-table" style="font-size: 13px;">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Client</th>
+                            <th>Type</th>
+                            <th>Montant</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${recentOps.length === 0 ? `
+                            <tr><td colspan="5" style="text-align: center; color: var(--qw-text-secondary);">Aucune opération</td></tr>
+                        ` : recentOps.map(op => `
+                            <tr>
+                                <td>${escapeHtml(op.operation_date || '')}</td>
+                                <td>${escapeHtml(op.client_name || '')}</td>
+                                <td>${op.operation_type === 'credit'
+                                    ? '<span class="badge-success">Avance</span>'
+                                    : '<span class="badge-danger">Remboursement</span>'}</td>
+                                <td>${fmt(op.amount)}</td>
+                                <td style="color: var(--qw-text-secondary);">${escapeHtml(op.description || '—')}</td>
+                            </tr>
+                        `).join('')}
+                    </tbody>
+                </table>
+            </div>`;
+    } catch (error) {
+        console.error('Erreur loadCreanceMultiAccountData:', error);
+        container.innerHTML = `
+            <div class="no-data-message">
+                <i class="fas fa-exclamation-triangle"></i>
+                <p>Erreur de chargement</p>
+                <small>${escapeHtml(error.message)}</small>
+            </div>`;
+    }
+}
+
+// =====================================================
+// VUE GLOBALE CRÉANCE — appelle /external/api/creance
+// avec un système d'exclusions de clients (Keur Baly par
+// défaut, ajout/retrait possible).
+// =====================================================
+
+// État local des exclusions (init avec Keur Baly par défaut)
+let creanceGlobalExclusions = ['Keur Baly'];
+let creanceGlobalListenersAttached = false;
+
+function setupCreanceGlobalView() {
+    if (creanceGlobalListenersAttached) return;
+
+    const dateInput = document.getElementById('creance-global-date');
+    const addBtn = document.getElementById('creance-global-exclusion-add');
+    const inputEl = document.getElementById('creance-global-exclusion-input');
+    const refreshBtn = document.getElementById('creance-global-refresh');
+    const accordionHeader = document.getElementById('creance-global-header');
+    const accordionContent = document.getElementById('creance-global-content');
+
+    if (!dateInput || !addBtn || !inputEl || !refreshBtn || !accordionHeader) return;
+
+    // Date par défaut = aujourd'hui
+    const today = new Date();
+    const toLocal = (d) => {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    };
+    dateInput.value = toLocal(today);
+
+    // Render chips initiaux
+    renderCreanceGlobalChips();
+
+    // Toggle accordéon : charge automatiquement au premier expand
+    accordionHeader.addEventListener('click', async () => {
+        const isCollapsed = accordionHeader.classList.contains('collapsed');
+        if (isCollapsed) {
+            accordionHeader.classList.remove('collapsed');
+            accordionContent.classList.remove('collapsed');
+            accordionHeader.setAttribute('aria-expanded', 'true');
+            if (!accordionContent.dataset.loaded) {
+                await runCreanceGlobalQuery();
+                accordionContent.dataset.loaded = 'true';
+            }
+        } else {
+            accordionHeader.classList.add('collapsed');
+            accordionContent.classList.add('collapsed');
+            accordionHeader.setAttribute('aria-expanded', 'false');
+        }
+    });
+
+    // Ajout d'une exclusion par bouton ou Enter
+    const addExclusion = () => {
+        const raw = inputEl.value.trim();
+        if (!raw) return;
+        // Évite les doublons case-insensitive
+        const exists = creanceGlobalExclusions.some(c => c.toLowerCase() === raw.toLowerCase());
+        if (exists) {
+            showNotification(`"${raw}" est déjà dans la liste`, 'warning');
+            inputEl.value = '';
+            return;
+        }
+        creanceGlobalExclusions.push(raw);
+        inputEl.value = '';
+        renderCreanceGlobalChips();
+    };
+    addBtn.addEventListener('click', addExclusion);
+    inputEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            addExclusion();
+        }
+    });
+
+    // Actualiser
+    refreshBtn.addEventListener('click', runCreanceGlobalQuery);
+
+    creanceGlobalListenersAttached = true;
+}
+
+function renderCreanceGlobalChips() {
+    const container = document.getElementById('creance-global-exclusion-chips');
+    if (!container) return;
+    if (creanceGlobalExclusions.length === 0) {
+        container.innerHTML = '<small style="color: var(--qw-text-muted);">Aucune exclusion. Tous les clients seront inclus.</small>';
+        return;
+    }
+    container.innerHTML = creanceGlobalExclusions.map((name, i) => `
+        <span class="client-badge" style="font-size: 12px; padding: 4px 10px; cursor: default;">
+            ${escapeHtml(name)}
+            <button type="button" class="client-badge-action remove-icon"
+                    data-exclusion-index="${i}" aria-label="Retirer ${escapeHtml(name)}">
+                <i class="fas fa-times-circle" aria-hidden="true"></i>
+            </button>
+        </span>
+    `).join('');
+    container.querySelectorAll('[data-exclusion-index]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const idx = parseInt(btn.dataset.exclusionIndex, 10);
+            creanceGlobalExclusions.splice(idx, 1);
+            renderCreanceGlobalChips();
+        });
+    });
+}
+
+async function runCreanceGlobalQuery() {
+    const resultsEl = document.getElementById('creance-global-results');
+    const dateInput = document.getElementById('creance-global-date');
+    if (!resultsEl) return;
+
+    // Skeleton de chargement
+    resultsEl.innerHTML = `
+        <div class="skeleton-card" style="margin-bottom: 12px;">
+            <div class="skeleton skeleton-title"></div>
+            <div class="skeleton skeleton-text"></div>
+            <div class="skeleton skeleton-text medium"></div>
+        </div>
+        <div class="skeleton-card">
+            <div class="skeleton skeleton-title"></div>
+            <div class="skeleton skeleton-text long"></div>
+            <div class="skeleton skeleton-text"></div>
+        </div>`;
+
+    try {
+        const params = new URLSearchParams();
+        if (dateInput && dateInput.value) params.set('date', dateInput.value);
+        if (creanceGlobalExclusions.length > 0) {
+            params.set('exclusionClients', creanceGlobalExclusions.join(';'));
+        }
+        const response = await fetch(`/external/api/creance?${params.toString()}`);
+        if (!response.ok) {
+            const errText = await response.text();
+            throw new Error(`HTTP ${response.status} — ${errText.slice(0, 200)}`);
+        }
+        const data = await response.json();
+        renderCreanceGlobalResults(data);
+    } catch (error) {
+        console.error('Erreur vue globale créance:', error);
+        resultsEl.innerHTML = `
+            <div class="no-data-message">
+                <i class="fas fa-exclamation-triangle"></i>
+                <p>Erreur lors du chargement</p>
+                <small>${escapeHtml(error.message)}</small>
+            </div>`;
+    }
+}
+
+function renderCreanceGlobalResults(data) {
+    const resultsEl = document.getElementById('creance-global-results');
+    if (!resultsEl || !data) return;
+
+    const fmt = n => (parseFloat(n) || 0).toLocaleString('fr-FR') + ' FCFA';
+    const summary = data.summary || {};
+    const totals = summary.totals || {};
+    const portfolios = summary.portfolios || [];
+    const details = data.details || [];
+    const ai = data.ai_insights || {};
+    const excluded = (data.metadata && data.metadata.excluded_clients) || [];
+
+    // Trend pour le total
+    const totalTrend = renderTrend(totals.current_balance, totals.previous_balance, {
+        label: `vs ${summary.date_previous || 'veille'}`,
+        inverse: false
+    });
+
+    // Cards par portfolio
+    const portfolioCards = portfolios.map(p => {
+        const trend = renderTrend(p.current_balance, p.previous_balance, { inverse: false });
+        return `
+            <div class="section-card" style="padding: 14px 16px; margin: 0;">
+                <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px;
+                            color: var(--qw-text-secondary); margin-bottom: 4px;">
+                    ${escapeHtml(p.portfolio_name || '—')}
+                </div>
+                <div style="font-size: 18px; font-weight: 700; color: var(--qw-text); margin-bottom: 4px;">
+                    ${fmt(p.current_balance)}
+                </div>
+                <div>${trend}</div>
+                <div style="font-size: 11px; color: var(--qw-text-muted); margin-top: 6px;">
+                    Directeur : ${escapeHtml(p.assigned_director || '—')}
+                </div>
+            </div>`;
+    }).join('');
+
+    // AI insights
+    const aiBlock = ai.error
+        ? `<div class="no-data-message" style="text-align: left; padding: 16px;">
+               <p style="margin: 0; color: var(--qw-text-secondary);"><i class="fas fa-robot"></i> Analyse IA indisponible</p>
+               <small>${escapeHtml(ai.error)}</small>
+           </div>`
+        : `<div class="section-card" style="padding: 16px; margin: 0;">
+               <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px;
+                           color: var(--qw-text-secondary); margin-bottom: 8px;">
+                   <i class="fas fa-brain"></i> Analyse IA
+                   <span style="font-weight: 400; text-transform: none; opacity: 0.7;">
+                       (${escapeHtml(ai.model_used || '')}, ${ai.tokens_used || 0} tokens)
+                   </span>
+               </div>
+               <div style="line-height: 1.6; color: var(--qw-text); white-space: pre-line;">
+                   ${escapeHtml(ai.analysis || '—')}
+               </div>
+           </div>`;
+
+    // Accordions de détails par portfolio
+    const detailsAccordions = details.map((d, i) => `
+        <div class="section-card" style="margin-bottom: 10px;" data-portfolio-index="${i}">
+            <button type="button" class="accordion-header collapsed">
+                <span><i class="fas fa-folder"></i> ${escapeHtml(d.portfolio_name || '—')}
+                    <small style="margin-left: 8px; font-weight: 400; opacity: 0.8;">
+                        ${(d.status || []).length} clients · ${(d.operations || []).length} opérations
+                    </small>
+                </span>
+                <i class="fas fa-chevron-down accordion-icon"></i>
+            </button>
+            <div class="accordion-content collapsed">
+                <h5 style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px;
+                           color: var(--qw-text-secondary); margin: 0 0 8px;">Clients</h5>
+                <div class="table-container" style="margin-bottom: 16px;">
+                    <table class="data-table" style="font-size: 13px;">
+                        <thead>
+                            <tr>
+                                <th>Client</th>
+                                <th>Crédit initial</th>
+                                <th>Avances</th>
+                                <th>Remboursements</th>
+                                <th>Solde</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            ${(d.status || []).length === 0
+                                ? `<tr><td colspan="5" style="text-align: center; color: var(--qw-text-secondary);">Aucun client (peut-être tous exclus)</td></tr>`
+                                : d.status.map(c => `
+                                    <tr>
+                                        <td>${escapeHtml(c.client_name || '')}</td>
+                                        <td>${fmt(c.credit_initial)}</td>
+                                        <td>${fmt(c.total_avances)}</td>
+                                        <td>${fmt(c.total_remboursements)}</td>
+                                        <td><strong>${fmt(c.solde_final)}</strong></td>
+                                    </tr>
+                                `).join('')}
+                        </tbody>
+                    </table>
+                </div>
+                <h5 style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px;
+                           color: var(--qw-text-secondary); margin: 0 0 8px;">Opérations récentes (10)</h5>
+                <div class="table-container">
+                    <table class="data-table" style="font-size: 13px;">
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Client</th>
+                                <th>Type</th>
+                                <th>Montant</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            ${(d.operations || []).slice(0, 10).length === 0
+                                ? `<tr><td colspan="4" style="text-align: center; color: var(--qw-text-secondary);">Aucune opération</td></tr>`
+                                : d.operations.slice(0, 10).map(op => `
+                                    <tr>
+                                        <td>${escapeHtml(op.date_operation || '')}</td>
+                                        <td>${escapeHtml(op.client || '')}</td>
+                                        <td>${op.type === 'avance' || op.type === 'credit'
+                                            ? '<span class="badge-success">Avance</span>'
+                                            : '<span class="badge-danger">Remboursement</span>'}</td>
+                                        <td>${fmt(op.montant)}</td>
+                                    </tr>
+                                `).join('')}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    `).join('');
+
+    resultsEl.innerHTML = `
+        <!-- Bandeau totaux -->
+        <div class="section-card" style="display: flex; align-items: center; gap: 24px;
+                                          flex-wrap: wrap; padding: 16px 20px; margin-bottom: 16px;">
+            <div>
+                <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px;
+                            color: var(--qw-text-secondary);">Solde total ${summary.date_selected ? `au ${summary.date_selected}` : ''}</div>
+                <div style="font-size: 24px; font-weight: 700; color: var(--qw-text);">${fmt(totals.current_balance)}</div>
+                <div style="margin-top: 4px;">${totalTrend}</div>
+            </div>
+            <div style="border-left: 1px solid var(--qw-border); padding-left: 20px;">
+                <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px;
+                            color: var(--qw-text-secondary);">Portefeuilles</div>
+                <div style="font-size: 18px; font-weight: 600; color: var(--qw-text);">${summary.portfolios_count || portfolios.length}</div>
+            </div>
+            ${excluded.length > 0 ? `
+                <div style="border-left: 1px solid var(--qw-border); padding-left: 20px;">
+                    <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px;
+                                color: var(--qw-text-secondary);">Clients exclus</div>
+                    <div style="font-size: 14px; color: var(--qw-text); margin-top: 2px;">
+                        ${excluded.map(e => escapeHtml(e)).join(', ')}
+                    </div>
+                </div>` : ''}
+        </div>
+
+        <!-- Grille de cards par portfolio -->
+        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+                    gap: 12px; margin-bottom: 18px;">
+            ${portfolioCards}
+        </div>
+
+        <!-- Analyse IA -->
+        <div style="margin-bottom: 18px;">${aiBlock}</div>
+
+        <!-- Détails accordions -->
+        <h5 style="font-size: 13px; text-transform: uppercase; letter-spacing: 0.4px;
+                   color: var(--qw-text-secondary); margin: 0 0 10px;">Détails par portefeuille</h5>
+        ${detailsAccordions || '<div class="no-data-message"><p>Aucun détail disponible</p></div>'}`;
+
+    // Attacher handlers aux nouveaux accordions
+    resultsEl.querySelectorAll('.accordion-header').forEach(header => {
+        header.addEventListener('click', () => {
+            const card = header.closest('.section-card');
+            const content = card.querySelector('.accordion-content');
+            const isCollapsed = header.classList.contains('collapsed');
+            if (isCollapsed) {
+                header.classList.remove('collapsed');
+                content.classList.remove('collapsed');
+                header.setAttribute('aria-expanded', 'true');
+            } else {
+                header.classList.add('collapsed');
+                content.classList.add('collapsed');
+                header.setAttribute('aria-expanded', 'false');
+            }
+        });
+    });
+}
+
+/** Bascule de la vue multi vers la vue single pour gérer/éditer un compte. */
+function switchToSingleCreanceMode(accountId) {
+    const toggle = document.getElementById('creance-multi-mode-toggle');
+    const select = document.getElementById('creance-account-select');
+    if (toggle) {
+        toggle.checked = false;
+        toggle.dispatchEvent(new Event('change'));
+    }
+    if (select) {
+        select.value = String(accountId);
+        handleCreanceAccountSelection();
+        select.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
 }
 
@@ -15809,10 +16423,13 @@ async function handleAddOperation(event) {
 
 // Initialiser la section créance
 async function initCreanceSection() {
-    
+
     // Charger les comptes créance
     await loadCreanceAccounts();
-    
+
+    // Initialiser la vue globale (chips d'exclusion + accordéon)
+    setupCreanceGlobalView();
+
     // Gérer la sélection du compte
     const accountSelect = document.getElementById('creance-account-select');
     if (accountSelect) {
@@ -16036,18 +16653,25 @@ let canEditCashBictorys = false;
 
 // Initialiser la section Cash Bictorys
 async function initCashBictorysSection() {
-    
+
     // Définir le mois en cours par défaut
     const today = new Date();
     const currentMonth = `${today.getFullYear()}-${(today.getMonth() + 1).toString().padStart(2, '0')}`;
-    
+
     const monthInput = document.getElementById('cash-bictorys-month');
     if (monthInput) {
         monthInput.value = currentMonth;
     }
-    
+
     // Événements
     setupCashBictorysEventListeners();
+
+    // Auto-charger le mois en cours
+    try {
+        await loadCashBictorysMonth(currentMonth);
+    } catch (e) {
+        console.warn('⚠️ Auto-load Cash Bictorys échoué (non bloquant) :', e.message);
+    }
 }
 
 // Configurer les événements Cash Bictorys
@@ -16723,21 +17347,29 @@ function createSoldeChart() {
 // Configurer les dates par défaut
 function setupVisualisationDateControls() {
     const today = new Date();
-    const ninetyDaysAgo = new Date(today);
-    ninetyDaysAgo.setDate(today.getDate() - 90);
-    
+    // Premier jour du mois en cours (local time pour éviter les surprises de timezone)
+    const firstOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+
+    // Format YYYY-MM-DD en local (toISOString partirait en UTC et pourrait
+    // décaler d'un jour pour les premières heures locales)
+    const toLocalDateString = (d) => {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    };
+
     const startDateInput = document.getElementById('viz-start-date');
     const endDateInput = document.getElementById('viz-end-date');
-    
+
     if (startDateInput) {
-        startDateInput.value = ninetyDaysAgo.toISOString().split('T')[0];
+        startDateInput.value = toLocalDateString(firstOfMonth);
     }
-    
     if (endDateInput) {
-        endDateInput.value = today.toISOString().split('T')[0];
+        endDateInput.value = toLocalDateString(today);
     }
-    
-    console.log(`📅 CLIENT: Dates par défaut configurées: ${ninetyDaysAgo.toISOString().split('T')[0]} à ${today.toISOString().split('T')[0]}`);
+
+    console.log(`📅 CLIENT: Dates par défaut configurées (mois en cours): ${toLocalDateString(firstOfMonth)} à ${toLocalDateString(today)}`);
 }
 
 // Configurer les événements des onglets
@@ -17086,19 +17718,26 @@ function updateVisualisationTable(tab, data) {
 // Configurer les contrôles de date pour la visualisation
 function setupVisualisationDateControls() {
     console.log('📅 CLIENT: Configuration des contrôles de date visualisation');
-    
-    // Définir les dates par défaut (derniers 90 jours pour avoir plus de données)
+
+    // Défaut : 1er jour du mois en cours → aujourd'hui
     const endDate = new Date();
-    const startDate = new Date();
-    startDate.setDate(endDate.getDate() - 90);
-    
+    const startDate = new Date(endDate.getFullYear(), endDate.getMonth(), 1);
+
+    // Format YYYY-MM-DD en heure locale (toISOString partirait en UTC)
+    const toLocalDateString = (d) => {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    };
+
     const startDateInput = document.getElementById('viz-start-date');
     const endDateInput = document.getElementById('viz-end-date');
-    
-    if (startDateInput) startDateInput.value = startDate.toISOString().split('T')[0];
-    if (endDateInput) endDateInput.value = endDate.toISOString().split('T')[0];
-    
-    console.log(`📅 CLIENT: Dates par défaut configurées: ${startDate.toISOString().split('T')[0]} à ${endDate.toISOString().split('T')[0]}`);
+
+    if (startDateInput) startDateInput.value = toLocalDateString(startDate);
+    if (endDateInput) endDateInput.value = toLocalDateString(endDate);
+
+    console.log(`📅 CLIENT: Dates par défaut configurées (mois en cours): ${toLocalDateString(startDate)} à ${toLocalDateString(endDate)}`);
 }
 
 // Configurer les onglets de visualisation

--- a/public/app.js
+++ b/public/app.js
@@ -4442,7 +4442,24 @@ function setDefaultDate() {
 document.addEventListener('DOMContentLoaded', function() {
     // Event listener pour le bouton info du Cash disponible
     setupCashDetailModal();
-    
+
+    // ---- Fail-safe loader : on garantit que body.nav-ready finit toujours
+    // par être posé, même si l'auth/init throw ou hang. Sinon l'utilisateur
+    // se retrouve coincé sur le spinner. ----
+    const NAV_READY_TIMEOUT_MS = 10000;
+    const navReadyFallbackId = setTimeout(() => {
+        if (!document.body.classList.contains('nav-ready')) {
+            console.warn('⚠️ nav-ready forcé par fail-safe timeout après ' + NAV_READY_TIMEOUT_MS + 'ms');
+            document.body.classList.add('nav-ready');
+        }
+    }, NAV_READY_TIMEOUT_MS);
+    const markNavReady = () => {
+        clearTimeout(navReadyFallbackId);
+        if (!document.body.classList.contains('nav-ready')) {
+            requestAnimationFrame(() => document.body.classList.add('nav-ready'));
+        }
+    };
+
     // Vérifier si l'utilisateur est déjà connecté
     fetch('/api/user')
         .then(response => {
@@ -4453,18 +4470,21 @@ document.addEventListener('DOMContentLoaded', function() {
         })
         .then(async user => {
             currentUser = user;
-            await showApp();
-            await loadInitialData();
-            // loadInitialData() ajoute lui-même nav-ready (qui cache le loader)
+            try {
+                await showApp();
+                await loadInitialData();
+                // loadInitialData() ajoute déjà nav-ready côté happy path.
+            } finally {
+                // Garantit que même si showApp/loadInitialData throw,
+                // le loader disparaît et l'app devient interactive.
+                markNavReady();
+            }
         })
         .catch((error) => {
             // Erreur normale au démarrage si non connecté
             console.log('Utilisateur non connecté, affichage de la page de connexion');
             showLogin();
-            // Pas de loadInitialData en mode non-connecté → on retire le loader nous-même
-            requestAnimationFrame(() => {
-                document.body.classList.add('nav-ready');
-            });
+            markNavReady();
         });
     
     // Gestionnaire de formulaire de connexion
@@ -15374,6 +15394,10 @@ async function loadCreanceMultiAccountData(accountId, container) {
 // État local des exclusions (init avec Keur Baly par défaut)
 let creanceGlobalExclusions = ['Keur Baly'];
 let creanceGlobalListenersAttached = false;
+// Vue active : 'portfolio' (par défaut) ou 'client' (synthèse cross-comptes)
+let creanceGlobalViewMode = 'portfolio';
+// Dernier payload reçu (pour basculer entre les vues sans refetcher)
+let creanceGlobalLastData = null;
 
 function setupCreanceGlobalView() {
     if (creanceGlobalListenersAttached) return;
@@ -15517,6 +15541,8 @@ async function runCreanceGlobalQuery() {
 function renderCreanceGlobalResults(data) {
     const resultsEl = document.getElementById('creance-global-results');
     if (!resultsEl || !data) return;
+    // Cache pour permettre la bascule de vue sans refetch
+    creanceGlobalLastData = data;
 
     const fmt = n => (parseFloat(n) || 0).toLocaleString('fr-FR') + ' FCFA';
     const summary = data.summary || {};
@@ -15642,10 +15668,10 @@ function renderCreanceGlobalResults(data) {
         </div>
     `).join('');
 
-    resultsEl.innerHTML = `
-        <!-- Bandeau totaux -->
+    // ===== Bandeau commun (totaux + écart vs veille) — utilisé par les 2 vues
+    const headerBandeau = `
         <div class="section-card" style="display: flex; align-items: center; gap: 24px;
-                                          flex-wrap: wrap; padding: 16px 20px; margin-bottom: 16px;">
+                                          flex-wrap: wrap; padding: 16px 20px; margin-bottom: 12px;">
             <div>
                 <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px;
                             color: var(--qw-text-secondary);">Solde total ${summary.date_selected ? `au ${summary.date_selected}` : ''}</div>
@@ -15665,23 +15691,49 @@ function renderCreanceGlobalResults(data) {
                         ${excluded.map(e => escapeHtml(e)).join(', ')}
                     </div>
                 </div>` : ''}
-        </div>
+        </div>`;
 
-        <!-- Grille de cards par portfolio -->
-        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-                    gap: 12px; margin-bottom: 18px;">
-            ${portfolioCards}
-        </div>
+    // ===== Pill switcher : Par portefeuille / Par client
+    const viewSwitcher = `
+        <div class="qw-view-switcher" role="tablist" aria-label="Mode de vue">
+            <button type="button" role="tab"
+                    class="qw-view-pill ${creanceGlobalViewMode === 'portfolio' ? 'is-active' : ''}"
+                    data-view="portfolio"
+                    aria-selected="${creanceGlobalViewMode === 'portfolio'}">
+                <i class="fas fa-folder-tree"></i> Par portefeuille
+            </button>
+            <button type="button" role="tab"
+                    class="qw-view-pill ${creanceGlobalViewMode === 'client' ? 'is-active' : ''}"
+                    data-view="client"
+                    aria-selected="${creanceGlobalViewMode === 'client'}">
+                <i class="fas fa-users"></i> Par client
+            </button>
+        </div>`;
 
-        <!-- Analyse IA -->
-        <div style="margin-bottom: 18px;">${aiBlock}</div>
+    // ===== Construction du body en fonction du mode
+    let bodyHtml = '';
+    if (creanceGlobalViewMode === 'portfolio') {
+        bodyHtml = `
+            <!-- Grille de cards par portfolio -->
+            <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+                        gap: 12px; margin-bottom: 18px;">
+                ${portfolioCards}
+            </div>
 
-        <!-- Détails accordions -->
-        <h5 style="font-size: 13px; text-transform: uppercase; letter-spacing: 0.4px;
-                   color: var(--qw-text-secondary); margin: 0 0 10px;">Détails par portefeuille</h5>
-        ${detailsAccordions || '<div class="no-data-message"><p>Aucun détail disponible</p></div>'}`;
+            <!-- Analyse IA -->
+            <div style="margin-bottom: 18px;">${aiBlock}</div>
 
-    // Attacher handlers aux nouveaux accordions
+            <!-- Détails accordions -->
+            <h5 style="font-size: 13px; text-transform: uppercase; letter-spacing: 0.4px;
+                       color: var(--qw-text-secondary); margin: 0 0 10px;">Détails par portefeuille</h5>
+            ${detailsAccordions || '<div class="no-data-message"><p>Aucun détail disponible</p></div>'}`;
+    } else {
+        bodyHtml = renderCreanceGlobalByClient(data);
+    }
+
+    resultsEl.innerHTML = headerBandeau + viewSwitcher + bodyHtml;
+
+    // Handlers : accordions
     resultsEl.querySelectorAll('.accordion-header').forEach(header => {
         header.addEventListener('click', () => {
             const card = header.closest('.section-card');
@@ -15698,6 +15750,230 @@ function renderCreanceGlobalResults(data) {
             }
         });
     });
+
+    // Handlers : view switcher
+    resultsEl.querySelectorAll('.qw-view-pill').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const mode = btn.dataset.view;
+            if (!mode || mode === creanceGlobalViewMode) return;
+            creanceGlobalViewMode = mode;
+            // Re-render à partir du cache, sans refetch
+            if (creanceGlobalLastData) renderCreanceGlobalResults(creanceGlobalLastData);
+        });
+    });
+}
+
+/**
+ * Vue "Par client" — synthèse cross-comptes :
+ * - Pour chaque client, on agrège son solde, son portefeuille, sa
+ *   dernière avance et son dernier remboursement (à partir des
+ *   opérations disponibles dans la réponse de l'API).
+ * - Partie 1 : clients ayant au moins une opération sur la période
+ * - Partie 2 : clients sans aucune opération (solde dormant)
+ */
+function renderCreanceGlobalByClient(data) {
+    const fmt = n => (parseFloat(n) || 0).toLocaleString('fr-FR') + ' FCFA';
+    const fmtDate = d => {
+        if (!d) return '';
+        // ISO YYYY-MM-DD -> reste tel quel (les utilisateurs préfèrent cette forme dans le tableau)
+        const s = String(d).slice(0, 10);
+        return s;
+    };
+    const details = data.details || [];
+    const summary = data.summary || {};
+    const today = summary.date_selected ? new Date(summary.date_selected) : new Date();
+
+    // Index : clientKey -> { name, portfolio, solde, lastAvance, lastRemb }
+    const clientMap = new Map();
+    const keyOf = name => (name || '').trim().toLowerCase();
+
+    details.forEach(d => {
+        const pname = d.portfolio_name || '—';
+        (d.status || []).forEach(c => {
+            const k = keyOf(c.client_name);
+            if (!k) return;
+            // Si un client apparaît dans plusieurs portefeuilles, on garde
+            // celui dont le solde absolu est le plus élevé (cas marginal).
+            const prev = clientMap.get(k);
+            const entry = {
+                name: c.client_name,
+                portfolio: pname,
+                solde: parseFloat(c.solde_final || 0),
+                credit_initial: parseFloat(c.credit_initial || 0),
+                total_avances: parseFloat(c.total_avances || 0),
+                total_remboursements: parseFloat(c.total_remboursements || 0),
+                lastAvance: null,    // { date, montant }
+                lastRemb: null
+            };
+            if (!prev || Math.abs(entry.solde) > Math.abs(prev.solde)) {
+                clientMap.set(k, entry);
+            }
+        });
+        // Parcourir les opérations pour identifier dernière avance / dernier remb
+        (d.operations || []).forEach(op => {
+            const k = keyOf(op.client);
+            const entry = clientMap.get(k);
+            if (!entry) return;
+            const dateStr = fmtDate(op.date_operation);
+            const isAvance = op.type === 'avance' || op.type === 'credit';
+            const slot = isAvance ? 'lastAvance' : 'lastRemb';
+            if (!entry[slot] || dateStr > entry[slot].date) {
+                entry[slot] = { date: dateStr, montant: parseFloat(op.montant || 0) };
+            }
+        });
+    });
+
+    // Tri par solde décroissant (comme dans le screenshot)
+    const allClients = Array.from(clientMap.values()).sort((a, b) => b.solde - a.solde);
+
+    // Séparation : actif (au moins une opération) vs sans activité
+    const actifs = [];
+    const inactifs = [];
+    allClients.forEach(c => {
+        if (c.lastAvance || c.lastRemb) actifs.push(c);
+        else inactifs.push(c);
+    });
+
+    // Helper : nombre de jours depuis la dernière activité
+    const daysSince = entry => {
+        const lastDateStr = [entry.lastAvance && entry.lastAvance.date,
+                             entry.lastRemb && entry.lastRemb.date]
+                             .filter(Boolean).sort().reverse()[0];
+        if (!lastDateStr) return null;
+        const lastDate = new Date(lastDateStr);
+        const diff = Math.floor((today - lastDate) / (1000 * 60 * 60 * 24));
+        return Math.max(0, diff);
+    };
+
+    // Badge "Compte"
+    const portfolioBadge = name => `
+        <span class="qw-pill qw-pill-muted" title="Portefeuille">
+            <i class="fas fa-folder"></i> ${escapeHtml(name)}
+        </span>`;
+
+    // Pill date avec couleur selon âge (mois courant = bleu, sinon neutre)
+    const datePill = (item, isPositive = false) => {
+        if (!item) return `<span class="qw-cell-empty">—</span>`;
+        const sameMonth = item.date && item.date.slice(0, 7) === (summary.date_selected || '').slice(0, 7);
+        const cls = sameMonth ? 'qw-pill qw-pill-primary' : 'qw-pill qw-pill-muted';
+        return `
+            <div class="qw-cell-stack">
+                <span class="${cls}">${escapeHtml(item.date)}</span>
+                <span class="qw-cell-amount ${isPositive ? 'qw-amount-pos' : ''}">${fmt(item.montant)}</span>
+            </div>`;
+    };
+
+    // Pill "Dernière activité : N jours"
+    const stalenessPill = entry => {
+        const d = daysSince(entry);
+        if (d === null) return `<span class="qw-pill qw-pill-warning">Aucune activité</span>`;
+        if (d > 60) return `<span class="qw-pill qw-pill-danger" title="Dernière activité"><i class="far fa-clock"></i> ${d} j</span>`;
+        if (d > 14) return `<span class="qw-pill qw-pill-warning" title="Dernière activité"><i class="far fa-clock"></i> ${d} j</span>`;
+        return `<span class="qw-pill qw-pill-success" title="Dernière activité"><i class="far fa-clock"></i> ${d} j</span>`;
+    };
+
+    // Solde coloré
+    const soldeCell = v => {
+        const cls = v < 0 ? 'qw-amount-neg' : (v === 0 ? 'qw-amount-zero' : 'qw-amount-pos');
+        return `<span class="qw-amount ${cls}">${fmt(v)}</span>`;
+    };
+
+    // Tableau pour la Partie 1
+    const renderActifsTable = () => `
+        <div class="table-container" style="margin-bottom: 18px;">
+            <table class="data-table qw-client-table">
+                <thead>
+                    <tr>
+                        <th style="width: 36px;">#</th>
+                        <th>Client</th>
+                        <th style="text-align: right;">Solde</th>
+                        <th>Dernier remboursement</th>
+                        <th>Dernière avance</th>
+                        <th>Compte</th>
+                        <th>Activité</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${actifs.map((c, i) => `
+                        <tr>
+                            <td class="qw-cell-rank">${i + 1}</td>
+                            <td><strong>${escapeHtml(c.name)}</strong></td>
+                            <td style="text-align: right;">${soldeCell(c.solde)}</td>
+                            <td>${datePill(c.lastRemb, true)}</td>
+                            <td>${datePill(c.lastAvance, false)}</td>
+                            <td>${portfolioBadge(c.portfolio)}</td>
+                            <td>${stalenessPill(c)}</td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        </div>`;
+
+    // Tableau pour la Partie 2
+    const renderInactifsTable = () => `
+        <div class="table-container">
+            <table class="data-table qw-client-table">
+                <thead>
+                    <tr>
+                        <th style="width: 36px;">#</th>
+                        <th>Client</th>
+                        <th style="text-align: right;">Solde</th>
+                        <th>Compte</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${inactifs.map((c, i) => `
+                        <tr>
+                            <td class="qw-cell-rank">${i + 1}</td>
+                            <td><strong>${escapeHtml(c.name)}</strong></td>
+                            <td style="text-align: right;">${soldeCell(c.solde)}</td>
+                            <td>${portfolioBadge(c.portfolio)}</td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        </div>`;
+
+    return `
+        <!-- Récap mini-stats par client -->
+        <div class="qw-client-summary">
+            <div class="qw-client-summary-item">
+                <span class="qw-client-summary-label">Clients suivis</span>
+                <span class="qw-client-summary-value">${allClients.length}</span>
+            </div>
+            <div class="qw-client-summary-item">
+                <span class="qw-client-summary-label">Avec activité</span>
+                <span class="qw-client-summary-value">${actifs.length}</span>
+            </div>
+            <div class="qw-client-summary-item">
+                <span class="qw-client-summary-label">Sans activité</span>
+                <span class="qw-client-summary-value">${inactifs.length}</span>
+            </div>
+        </div>
+
+        <!-- Partie 1 -->
+        <div class="qw-client-section">
+            <div class="qw-client-section-head">
+                <span class="qw-client-section-num">1</span>
+                <h5>Clients avec activité</h5>
+                <small>${actifs.length} client${actifs.length > 1 ? 's' : ''}, triés par solde décroissant</small>
+            </div>
+            ${actifs.length === 0
+                ? `<div class="no-data-message"><p>Aucun client avec activité sur la période</p></div>`
+                : renderActifsTable()}
+        </div>
+
+        <!-- Partie 2 -->
+        <div class="qw-client-section">
+            <div class="qw-client-section-head">
+                <span class="qw-client-section-num">2</span>
+                <h5>Sans activité</h5>
+                <small>Aucun remboursement ni avance — solde dormant</small>
+            </div>
+            ${inactifs.length === 0
+                ? `<div class="no-data-message"><p>Tous les clients ont eu une activité</p></div>`
+                : renderInactifsTable()}
+        </div>`;
 }
 
 /** Bascule de la vue multi vers la vue single pour gérer/éditer un compte. */
@@ -17345,10 +17621,17 @@ function createSoldeChart() {
 }
 
 // Configurer les dates par défaut
+// (définition unique — celle qui était dupliquée plus bas a été supprimée)
 function setupVisualisationDateControls() {
+    console.log('📅 CLIENT: Configuration des contrôles de date visualisation');
+
     const today = new Date();
-    // Premier jour du mois en cours (local time pour éviter les surprises de timezone)
-    const firstOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    // Premier jour du mois en cours : on clone today et on positionne le
+    // jour à 1 (plutôt que new Date(y, m, 1) qui utilise des paramètres
+    // numériques). Pas de souci de timezone : on reste dans le local time.
+    const firstOfMonth = new Date(today);
+    firstOfMonth.setDate(1);
+    firstOfMonth.setHours(0, 0, 0, 0);
 
     // Format YYYY-MM-DD en local (toISOString partirait en UTC et pourrait
     // décaler d'un jour pour les premières heures locales)
@@ -17714,31 +17997,10 @@ function updateVisualisationTable(tab, data) {
 }
 
 // ===== FONCTIONS SETUP POUR LE MODULE VISUALISATION =====
-
-// Configurer les contrôles de date pour la visualisation
-function setupVisualisationDateControls() {
-    console.log('📅 CLIENT: Configuration des contrôles de date visualisation');
-
-    // Défaut : 1er jour du mois en cours → aujourd'hui
-    const endDate = new Date();
-    const startDate = new Date(endDate.getFullYear(), endDate.getMonth(), 1);
-
-    // Format YYYY-MM-DD en heure locale (toISOString partirait en UTC)
-    const toLocalDateString = (d) => {
-        const y = d.getFullYear();
-        const m = String(d.getMonth() + 1).padStart(2, '0');
-        const day = String(d.getDate()).padStart(2, '0');
-        return `${y}-${m}-${day}`;
-    };
-
-    const startDateInput = document.getElementById('viz-start-date');
-    const endDateInput = document.getElementById('viz-end-date');
-
-    if (startDateInput) startDateInput.value = toLocalDateString(startDate);
-    if (endDateInput) endDateInput.value = toLocalDateString(endDate);
-
-    console.log(`📅 CLIENT: Dates par défaut configurées (mois en cours): ${toLocalDateString(startDate)} à ${toLocalDateString(endDate)}`);
-}
+// NOTE : setupVisualisationDateControls() est définie plus haut dans ce
+// fichier (recherche : "Configurer les dates par défaut"). La définition
+// dupliquée qui se trouvait ici a été supprimée pour éviter le piège du
+// hoisting (la dernière déclaration gagnait silencieusement).
 
 // Configurer les onglets de visualisation
 function setupVisualisationTabs() {

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,17 @@
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 </head>
 <body>
+    <!-- Loader global affiché pendant le chargement initial (avant
+         que JS ait fini l'auth + le setup des permissions).
+         Retiré par app.js via document.body.classList.add('nav-ready'). -->
+    <div id="qw-app-loader" aria-live="polite" aria-busy="true">
+        <div class="qw-app-loader-card">
+            <div class="qw-app-loader-spinner" aria-hidden="true"></div>
+            <div class="qw-app-loader-brand">MataBanq</div>
+            <div class="qw-app-loader-label">Chargement en cours…</div>
+        </div>
+    </div>
+
     <!-- Page de connexion -->
     <div id="login-page" class="page active">
         <div class="login-container">
@@ -1437,6 +1448,62 @@
                             <select id="creance-account-select" class="form-control">
                                 <option value="">Choisir un compte créance...</option>
                             </select>
+                        </div>
+
+                        <!-- Sélection multi-comptes (read-only view) -->
+                        <div class="creance-multi-selector" style="margin-top: 12px;">
+                            <label class="checkbox-label" style="display: inline-flex; align-items: center; gap: 8px; font-weight: 500; cursor: pointer;">
+                                <input type="checkbox" id="creance-multi-mode-toggle">
+                                <span>Vue multi-comptes (lecture seule)</span>
+                            </label>
+                            <div id="creance-multi-controls" style="display: none; margin-top: 10px;">
+                                <label class="checkbox-label" style="display: inline-flex; align-items: center; gap: 8px; font-weight: 600;">
+                                    <input type="checkbox" id="creance-select-all-accounts">
+                                    <span>Tout sélectionner</span>
+                                </label>
+                                <div id="creance-accounts-checkboxes" style="display: flex; flex-wrap: wrap; gap: 12px 18px; margin-top: 8px;">
+                                    <!-- Checkboxes générées dynamiquement -->
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Conteneur des accordéons multi-comptes (lecture seule) -->
+                    <div id="creance-multi-view" style="display: none;"></div>
+
+                    <!-- Vue globale (synthèse cross-comptes via /external/api/creance) -->
+                    <div class="section-card" id="creance-global-section" style="margin-top: 14px;">
+                        <button type="button" class="accordion-header collapsed" id="creance-global-header" aria-expanded="false" aria-controls="creance-global-content">
+                            <span><i class="fas fa-globe"></i> Vue globale (synthèse cross-comptes)</span>
+                            <i class="fas fa-chevron-down accordion-icon"></i>
+                        </button>
+                        <div class="accordion-content collapsed" id="creance-global-content">
+                            <div id="creance-global-filters" style="display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin-bottom: 16px;">
+                                <div class="form-group" style="margin: 0;">
+                                    <label for="creance-global-date">Date d'analyse</label>
+                                    <input type="date" id="creance-global-date" class="form-control" style="max-width: 200px;">
+                                </div>
+                                <div class="form-group" style="margin: 0; flex: 1; min-width: 280px;">
+                                    <label for="creance-global-exclusion-input">Clients à exclure</label>
+                                    <div style="display: flex; gap: 8px; align-items: center;">
+                                        <input type="text" id="creance-global-exclusion-input" class="form-control" placeholder="Nom du client (Enter pour ajouter)" style="flex: 1;">
+                                        <button type="button" id="creance-global-exclusion-add" class="btn btn-secondary">
+                                            <i class="fas fa-plus"></i> Ajouter
+                                        </button>
+                                    </div>
+                                    <div id="creance-global-exclusion-chips" style="display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px;"></div>
+                                </div>
+                                <button type="button" id="creance-global-refresh" class="btn btn-primary">
+                                    <i class="fas fa-sync-alt"></i> Actualiser
+                                </button>
+                            </div>
+                            <div id="creance-global-results">
+                                <div class="empty-state">
+                                    <div class="empty-state-icon"><i class="fas fa-chart-line"></i></div>
+                                    <h4>Cliquez sur Actualiser</h4>
+                                    <p>La vue globale agrège tous les comptes créance pour la date sélectionnée, avec exclusion des clients listés ci-dessus.</p>
+                                </div>
+                            </div>
                         </div>
                     </div>
 
@@ -2881,7 +2948,7 @@
 
                 <!-- Section Gestion Stock -->
                 <section id="stock-soir-section" class="section">
-                    <h2 style="color: #22c55e;">Gestion des Stocks du Soir</h2>
+                    <h2>Gestion des Stocks du Soir</h2>
                     
                     <!-- Upload de fichier JSON -->
                     <div class="stock-upload-card" style="display: none;">

--- a/public/styles.css
+++ b/public/styles.css
@@ -15147,3 +15147,219 @@ span.previsible-no,
 #stock-soir-section > h2 {
     color: var(--qw-text) !important;
 }
+
+/* =========================================================
+   CREANCE VUE GLOBALE — Bascule "Par portefeuille / Par client"
+   ========================================================= */
+
+/* Pill switcher */
+.qw-view-switcher {
+    display: inline-flex;
+    background: var(--qw-bg, #f3f4f6);
+    border: 1px solid var(--qw-border);
+    border-radius: 10px;
+    padding: 4px;
+    margin-bottom: 16px;
+    gap: 2px;
+}
+.qw-view-pill {
+    background: transparent;
+    border: none;
+    color: var(--qw-text-secondary);
+    padding: 6px 14px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: all 0.15s ease;
+}
+.qw-view-pill:hover {
+    color: var(--qw-text);
+}
+.qw-view-pill.is-active {
+    background: var(--qw-surface);
+    color: var(--qw-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+.qw-view-pill i {
+    font-size: 12px;
+}
+
+[data-theme="dark"] .qw-view-switcher {
+    background: rgba(255, 255, 255, 0.04);
+}
+[data-theme="dark"] .qw-view-pill.is-active {
+    background: var(--qw-surface);
+    color: var(--qw-primary);
+}
+
+/* Mini-récap au-dessus des tables clients */
+.qw-client-summary {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    padding: 12px 16px;
+    background: var(--qw-surface);
+    border: 1px solid var(--qw-border);
+    border-radius: var(--qw-radius-lg);
+    margin-bottom: 16px;
+}
+.qw-client-summary-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.qw-client-summary-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: var(--qw-text-secondary);
+}
+.qw-client-summary-value {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--qw-text);
+}
+
+/* En-tête de section "Partie 1 / Partie 2" */
+.qw-client-section {
+    margin-bottom: 24px;
+}
+.qw-client-section-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+.qw-client-section-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: var(--qw-primary-soft, #eff6ff);
+    color: var(--qw-primary);
+    font-size: 13px;
+    font-weight: 700;
+}
+.qw-client-section-head h5 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--qw-text);
+    text-transform: none;
+    letter-spacing: normal;
+}
+.qw-client-section-head small {
+    color: var(--qw-text-secondary);
+    font-size: 12px;
+    margin-left: auto;
+}
+
+[data-theme="dark"] .qw-client-section-num {
+    background: rgba(37, 99, 235, 0.15);
+}
+
+/* Table clients : cellules compactes + alignements */
+.qw-client-table {
+    font-size: 13px;
+}
+.qw-client-table td,
+.qw-client-table th {
+    vertical-align: middle;
+    padding: 10px 12px;
+}
+.qw-cell-rank {
+    color: var(--qw-text-secondary);
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+}
+.qw-cell-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: flex-start;
+}
+.qw-cell-amount {
+    font-size: 12px;
+    color: var(--qw-text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+.qw-cell-empty {
+    color: var(--qw-text-muted, #9ca3af);
+}
+
+/* Pills statut générique (utilisable hors créance aussi) */
+.qw-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 9px;
+    border-radius: 999px;
+    font-size: 11.5px;
+    font-weight: 500;
+    line-height: 1.4;
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+.qw-pill i {
+    font-size: 10px;
+}
+.qw-pill-muted {
+    background: rgba(0, 0, 0, 0.04);
+    color: var(--qw-text-secondary);
+    border-color: var(--qw-border);
+}
+.qw-pill-primary {
+    background: var(--qw-primary-soft, #eff6ff);
+    color: var(--qw-primary);
+    border-color: rgba(37, 99, 235, 0.2);
+}
+.qw-pill-success {
+    background: rgba(34, 197, 94, 0.1);
+    color: #15803d;
+    border-color: rgba(34, 197, 94, 0.25);
+}
+.qw-pill-warning {
+    background: rgba(245, 158, 11, 0.1);
+    color: #b45309;
+    border-color: rgba(245, 158, 11, 0.3);
+}
+.qw-pill-danger {
+    background: rgba(220, 38, 38, 0.1);
+    color: #b91c1c;
+    border-color: rgba(220, 38, 38, 0.3);
+}
+
+[data-theme="dark"] .qw-pill-muted {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--qw-text-secondary);
+}
+[data-theme="dark"] .qw-pill-success {
+    background: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
+}
+[data-theme="dark"] .qw-pill-warning {
+    background: rgba(245, 158, 11, 0.15);
+    color: #fbbf24;
+}
+[data-theme="dark"] .qw-pill-danger {
+    background: rgba(220, 38, 38, 0.18);
+    color: #f87171;
+}
+
+/* Montants colorés */
+.qw-amount {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+.qw-amount-pos { color: var(--qw-text); }
+.qw-amount-neg { color: #dc2626; }
+.qw-amount-zero { color: var(--qw-text-secondary); }
+
+[data-theme="dark"] .qw-amount-neg { color: #f87171; }
+

--- a/public/styles.css
+++ b/public/styles.css
@@ -11957,6 +11957,11 @@ body.comptable-mode .comptable-hide {
    tokens existants. Réversible : supprimer ce bloc pour revenir.
    ============================================================ */
 :root {
+    /* Indique à Chromium d'utiliser les contrôles natifs en thème clair
+       par défaut (sinon le menu déroulant des <select> hérite du thème
+       OS, donnant un dropdown sombre alors que la page est claire). */
+    color-scheme: light;
+
     /* Primary : bleu moderne style banking (Stripe, Wise, Revolut).
        On abandonne le violet pour un bleu neutre plus pro. */
     --qw-primary: #2563eb;            /* Tailwind blue-600 */
@@ -12261,6 +12266,112 @@ section .page-header h2 {
     background: #fbfbfd !important;
     border-right: 1px solid var(--qw-border) !important;
     box-shadow: none !important;
+}
+
+/* Anti-FOUC : cache la nav-menu ET le contenu principal tant que JS
+   n'a pas fini d'appliquer les permissions. Un loader full-screen
+   masque tout pendant ce temps. Tout fade-in ensemble. */
+.sidebar .nav-menu {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.25s ease-out;
+}
+body.nav-ready .sidebar .nav-menu {
+    visibility: visible;
+    opacity: 1;
+}
+
+/* Loader global plein écran — style banking pro */
+#qw-app-loader {
+    position: fixed;
+    inset: 0;
+    background: var(--qw-page);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10001;
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0.35s ease, visibility 0.35s ease;
+}
+body.nav-ready #qw-app-loader {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.qw-app-loader-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 22px;
+    padding: 40px 56px;
+    /* Petite "carte" douce pour un effet banking premium */
+    background: var(--qw-surface);
+    border: 1px solid var(--qw-border);
+    border-radius: 18px;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
+}
+
+/* Spinner : double anneau, le primary + un trail plus doux */
+.qw-app-loader-spinner {
+    width: 56px;
+    height: 56px;
+    position: relative;
+}
+.qw-app-loader-spinner::before,
+.qw-app-loader-spinner::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border-style: solid;
+    border-width: 3px;
+}
+.qw-app-loader-spinner::before {
+    border-color: transparent;
+    border-top-color: var(--qw-primary);
+    border-right-color: var(--qw-primary);
+    animation: qw-spin 1s linear infinite;
+}
+.qw-app-loader-spinner::after {
+    inset: 8px;
+    border-color: transparent;
+    border-bottom-color: rgba(37, 99, 235, 0.35);
+    border-left-color: rgba(37, 99, 235, 0.35);
+    animation: qw-spin 1.6s linear infinite reverse;
+}
+
+[data-theme="dark"] .qw-app-loader-spinner::after {
+    border-bottom-color: rgba(59, 130, 246, 0.5);
+    border-left-color: rgba(59, 130, 246, 0.5);
+}
+
+@keyframes qw-spin {
+    to { transform: rotate(360deg); }
+}
+
+.qw-app-loader-brand {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    color: var(--qw-primary);
+}
+
+.qw-app-loader-label {
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    color: var(--qw-text-muted);
+}
+
+/* Respect des préférences d'animation réduite */
+@media (prefers-reduced-motion: reduce) {
+    .qw-app-loader-spinner::before,
+    .qw-app-loader-spinner::after {
+        animation: none;
+    }
 }
 
 /* Items de nav : moins hauts, typo plus pro */
@@ -13866,6 +13977,7 @@ span.previsible-no,
 /* 1. Détection système (auto-activation si pas de pref enregistrée) */
 @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
+        color-scheme: dark;
         --qw-primary: #3b82f6;
         --qw-primary-hover: #60a5fa;
         --qw-primary-soft: rgba(59, 130, 246, 0.18);
@@ -13887,9 +13999,17 @@ span.previsible-no,
     }
 }
 
+/* Force light scheme si l'utilisateur a explicitement choisi le mode clair
+   (sinon Chromium dans un OS en dark mode rendrait quand même les
+   contrôles natifs en sombre). */
+:root[data-theme="light"] {
+    color-scheme: light;
+}
+
 /* 2. Override explicite via data-theme="dark" (priorité sur la détection système) */
 :root[data-theme="dark"],
 [data-theme="dark"] {
+    color-scheme: dark;
     --qw-primary: #3b82f6;
     --qw-primary-hover: #60a5fa;
     --qw-primary-soft: rgba(59, 130, 246, 0.18);
@@ -14557,6 +14677,45 @@ span.previsible-no,
     color: var(--qw-text-secondary) !important;
 }
 
+/* ============================================================
+   SNAPSHOTS CONTROLS — bandeau "Date de référence" violet → sobre
+   S'applique en light ET en dark (override universel)
+   ============================================================ */
+.snapshots-controls-section {
+    background: var(--qw-surface) !important;
+    background-image: none !important;
+    color: var(--qw-text) !important;
+    border: 1px solid var(--qw-border) !important;
+    border-left: 4px solid var(--qw-primary) !important;
+    box-shadow: var(--qw-shadow-sm) !important;
+}
+.snapshots-controls-section .control-panel .form-group label {
+    color: var(--qw-text) !important;
+}
+.snapshots-controls-section .form-help {
+    color: var(--qw-text-secondary) !important;
+}
+.snapshots-controls-section .form-control {
+    background: var(--qw-surface) !important;
+    color: var(--qw-text) !important;
+    border: 1px solid var(--qw-border) !important;
+}
+
+/* Dark mode : pareil mais surface dark */
+[data-theme="dark"] .snapshots-controls-section {
+    background: var(--qw-surface) !important;
+    background-image: none !important;
+    color: var(--qw-text) !important;
+}
+[data-theme="dark"] .snapshots-controls-section .form-control {
+    background: #131c2d !important;
+    color: var(--qw-text) !important;
+    border-color: var(--qw-border) !important;
+}
+[data-theme="dark"] .snapshots-controls-section .form-help {
+    color: var(--qw-text-secondary) !important;
+}
+
 /* Labels DANS .filters et .dashboard-filters (haute spécificité) */
 [data-theme="dark"] .filters label,
 [data-theme="dark"] .filters .form-group label,
@@ -14846,4 +15005,145 @@ span.previsible-no,
 }
 .qw-theme-toggle i {
     font-size: 14px;
+}
+
+/* =========================================================
+   STOCK SOIR — Uniformisation des couleurs
+   (titre vert + banner vert + boutons multicolores -> sobre)
+   ========================================================= */
+
+/* Banner "Total Stock Soir" : gradient vert -> carte sobre filet bleu */
+.stock-total-display {
+    background: var(--qw-surface) !important;
+    background-image: none !important;
+    border: 1px solid var(--qw-border) !important;
+    border-left: 4px solid var(--qw-primary) !important;
+    border-radius: var(--qw-radius-lg) !important;
+    box-shadow: var(--qw-shadow-sm) !important;
+    padding: 16px 20px !important;
+    margin: 16px 0 !important;
+}
+.stock-total-display .total-card {
+    color: var(--qw-text) !important;
+    text-align: left !important;
+}
+.stock-total-display .total-card h4 {
+    color: var(--qw-text-secondary) !important;
+    font-size: 13px !important;
+    font-weight: 500 !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.05em !important;
+    justify-content: flex-start !important;
+    margin: 0 0 6px 0 !important;
+}
+.stock-total-display .total-card h4 i {
+    color: var(--qw-primary) !important;
+}
+.stock-total-display .total-amount {
+    color: var(--qw-text) !important;
+    text-shadow: none !important;
+    font-size: 1.6rem !important;
+    font-weight: 700 !important;
+}
+
+/* Dark mode */
+[data-theme="dark"] .stock-total-display {
+    background: var(--qw-surface) !important;
+    border-color: var(--qw-border) !important;
+}
+[data-theme="dark"] .stock-total-display .total-card,
+[data-theme="dark"] .stock-total-display .total-amount {
+    color: var(--qw-text) !important;
+}
+[data-theme="dark"] .stock-total-display .total-card h4 {
+    color: var(--qw-text-secondary) !important;
+}
+
+/* Boutons d'action du header Stock Soir : tous en variantes sobres
+   #add-stock-btn (success vert), #view-stats-btn (info bleu),
+   #export-excel-btn (primary), #delete-by-date-btn (danger rouge)
+   -> garder UN seul accent primaire + ghost pour le reste. */
+#stock-soir-section .stock-controls .btn,
+#stock-soir-section .stock-actions .btn {
+    box-shadow: none !important;
+    background-image: none !important;
+}
+
+/* Action principale : Ajouter -> primaire */
+#stock-soir-section #add-stock-btn.btn,
+#stock-soir-section #add-stock-btn {
+    background: var(--qw-primary) !important;
+    color: #fff !important;
+    border: 1px solid var(--qw-primary) !important;
+}
+#stock-soir-section #add-stock-btn:hover {
+    background: var(--qw-primary-hover, #1d4ed8) !important;
+    border-color: var(--qw-primary-hover, #1d4ed8) !important;
+}
+
+/* Actions secondaires : Statistiques, Export, Supprimer par date -> ghost */
+#stock-soir-section #view-stats-btn,
+#stock-soir-section #export-excel-btn,
+#stock-soir-section #delete-by-date-btn {
+    background: var(--qw-surface) !important;
+    color: var(--qw-text) !important;
+    border: 1px solid var(--qw-border) !important;
+}
+#stock-soir-section #view-stats-btn:hover,
+#stock-soir-section #export-excel-btn:hover {
+    background: var(--qw-primary-soft, #eff6ff) !important;
+    color: var(--qw-primary) !important;
+    border-color: rgba(37, 99, 235, 0.3) !important;
+}
+/* Supprimer par date conserve un hint danger discret au hover uniquement */
+#stock-soir-section #delete-by-date-btn:hover {
+    background: rgba(220, 38, 38, 0.08) !important;
+    color: #b91c1c !important;
+    border-color: rgba(220, 38, 38, 0.3) !important;
+}
+
+/* Boutons d'action dans le tableau (Modifier violet / Supprimer rouge)
+   -> ghost neutres avec hint au hover */
+#stock-soir-section table .btn-warning,
+#stock-soir-section .stock-table .btn-warning,
+#stock-soir-section table .edit-stock-btn,
+#stock-soir-section .stock-table .edit-stock-btn {
+    background: transparent !important;
+    background-image: none !important;
+    color: var(--qw-text-secondary) !important;
+    border: 1px solid var(--qw-border) !important;
+    box-shadow: none !important;
+}
+#stock-soir-section table .btn-warning:hover,
+#stock-soir-section .stock-table .btn-warning:hover,
+#stock-soir-section table .edit-stock-btn:hover,
+#stock-soir-section .stock-table .edit-stock-btn:hover {
+    background: var(--qw-primary-soft, #eff6ff) !important;
+    color: var(--qw-primary) !important;
+    border-color: rgba(37, 99, 235, 0.3) !important;
+}
+
+#stock-soir-section table .btn-danger,
+#stock-soir-section .stock-table .btn-danger,
+#stock-soir-section table .delete-stock-btn,
+#stock-soir-section .stock-table .delete-stock-btn {
+    background: transparent !important;
+    background-image: none !important;
+    color: var(--qw-text-secondary) !important;
+    border: 1px solid var(--qw-border) !important;
+    box-shadow: none !important;
+}
+#stock-soir-section table .btn-danger:hover,
+#stock-soir-section .stock-table .btn-danger:hover,
+#stock-soir-section table .delete-stock-btn:hover,
+#stock-soir-section .stock-table .delete-stock-btn:hover {
+    background: rgba(220, 38, 38, 0.08) !important;
+    color: #b91c1c !important;
+    border-color: rgba(220, 38, 38, 0.3) !important;
+}
+
+/* Titre H2 de la section (le inline color:#22c55e a été retiré côté HTML,
+   on garantit ici la couleur standard) */
+#stock-soir-section > h2 {
+    color: var(--qw-text) !important;
 }

--- a/public/virement-mensuel.js
+++ b/public/virement-mensuel.js
@@ -45,6 +45,11 @@ function initVirementMensuel() {
     loadPointsDeVente();
     loadVirementClientsMeta();
 
+    // Auto-charger le mois en cours
+    loadVirementMensuel().catch(err => {
+        console.warn('⚠️ Auto-load Virement Mensuel échoué (non bloquant) :', err.message);
+    });
+
     console.log('✅ Module Virement Mensuel initialisé');
 }
 

--- a/public/virement-mensuel.js
+++ b/public/virement-mensuel.js
@@ -45,12 +45,19 @@ function initVirementMensuel() {
     loadPointsDeVente();
     loadVirementClientsMeta();
 
-    // Auto-charger le mois en cours
-    loadVirementMensuel().catch(err => {
-        console.warn('⚠️ Auto-load Virement Mensuel échoué (non bloquant) :', err.message);
-    });
-
-    console.log('✅ Module Virement Mensuel initialisé');
+    // Auto-charger le mois en cours.
+    // On awaite réellement la fin du chargement pour que le log "initialisé"
+    // ne fire qu'à la complétion. Les erreurs métier (réseau, parsing) sont
+    // déjà gérées à l'intérieur de loadVirementMensuel ; le catch ci-dessous
+    // ne sert qu'à attraper un échec inattendu (DOM manquant, runtime).
+    (async () => {
+        try {
+            await loadVirementMensuel();
+            console.log('✅ Module Virement Mensuel initialisé');
+        } catch (err) {
+            console.warn('⚠️ Init Virement Mensuel : échec inattendu (DOM/runtime) :', err && err.message ? err.message : err);
+        }
+    })();
 }
 
 // Charge la liste des points de vente actifs et peuple le <select>

--- a/start_preprod.bat
+++ b/start_preprod.bat
@@ -1,31 +1,42 @@
 @echo off
-echo 🧪 ==================================
-echo 🧪 TESTS DE NON-REGRESSION PRE-PUSH
-echo 🧪 ==================================
+echo =====================================
+echo TESTS DE NON-REGRESSION PRE-PUSH
+echo =====================================
 
-echo 📋 Configuration des variables d'environnement...
-set DB_HOST=localhost
-set DB_PORT=5432
-set DB_NAME=depenses_management_preprod_v2
-set DB_USER=zalint
-set DB_PASSWORD=bonea2024
+REM Les credentials NE doivent PAS etre embarques en clair dans ce script.
+REM Configurez DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD via votre
+REM secret manager ou votre shell avant d'invoquer ce script.
+if "%DB_HOST%"=="" goto :missing
+if "%DB_PORT%"=="" goto :missing
+if "%DB_NAME%"=="" goto :missing
+if "%DB_USER%"=="" goto :missing
+if "%DB_PASSWORD%"=="" goto :missing
+goto :run
+
+:missing
+echo ERREUR: Variables d'environnement manquantes.
+echo Requises: DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD.
+echo Configurez-les avant d'executer ce script.
+exit /b 1
+
+:run
 set NODE_ENV=test
 
-echo ⚡ Démarrage des tests de régression...
+echo Demarrage des tests de regression...
 call npm run test:regression
 
 if %ERRORLEVEL% NEQ 0 (
-    echo ❌ ==================================
-    echo ❌ TESTS DE REGRESSION ECHOUES!
-    echo ❌ ==================================
-    echo ❌ Les tests de non-régression ont échoué.
-    echo ❌ Corrigez les erreurs avant de continuer.
+    echo =====================================
+    echo TESTS DE REGRESSION ECHOUES
+    echo =====================================
+    echo Les tests de non-regression ont echoue.
+    echo Corrigez les erreurs avant de continuer.
     pause
     exit /b 1
 )
 
-echo ✅ ==================================
-echo ✅ TESTS DE REGRESSION REUSSIS!
-echo ✅ ==================================
-echo ✅ Tous les tests de non-régression sont passés.
+echo =====================================
+echo TESTS DE REGRESSION REUSSIS
+echo =====================================
+echo Tous les tests de non-regression sont passes.
 pause

--- a/start_preprod.bat
+++ b/start_preprod.bat
@@ -6,7 +6,7 @@ echo 🧪 ==================================
 echo 📋 Configuration des variables d'environnement...
 set DB_HOST=localhost
 set DB_PORT=5432
-set DB_NAME=depenses_management_preprod
+set DB_NAME=depenses_management_preprod_v2
 set DB_USER=zalint
 set DB_PASSWORD=bonea2024
 set NODE_ENV=test

--- a/start_preprod_new.ps1
+++ b/start_preprod_new.ps1
@@ -1,1 +1,1 @@
-$env:DB_HOST="localhost"; $env:DB_PORT="5432"; $env:DB_NAME="depenses_management_preprod"; $env:DB_USER="zalint"; $env:DB_PASSWORD="bonea2024"; node server.js
+$env:DB_HOST="localhost"; $env:DB_PORT="5432"; $env:DB_NAME="depenses_management_preprod_v2"; $env:DB_USER="zalint"; $env:DB_PASSWORD="bonea2024"; node server.js

--- a/start_preprod_new.ps1
+++ b/start_preprod_new.ps1
@@ -1,1 +1,17 @@
-$env:DB_HOST="localhost"; $env:DB_PORT="5432"; $env:DB_NAME="depenses_management_preprod_v2"; $env:DB_USER="zalint"; $env:DB_PASSWORD="bonea2024"; node server.js
+# Lance le serveur en mode pré-prod.
+# Les credentials NE doivent PAS être embarqués en clair dans ce script.
+# Configurez DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD via votre
+# secret manager ou votre shell avant d'invoquer ce script.
+$required = @('DB_HOST', 'DB_PORT', 'DB_NAME', 'DB_USER', 'DB_PASSWORD')
+$missing = @()
+foreach ($name in $required) {
+    $val = [Environment]::GetEnvironmentVariable($name)
+    if ([string]::IsNullOrEmpty($val)) {
+        $missing += $name
+    }
+}
+if ($missing.Count -gt 0) {
+    Write-Error "Variables d'environnement manquantes : $($missing -join ', '). Configurez-les via votre secret manager ou votre shell avant d'executer ce script."
+    exit 1
+}
+node server.js


### PR DESCRIPTION
…rmization

- Créance: multi-comptes view with checkboxes and read-only accordions
- Créance Vue Globale using /external/api/creance with editable exclusion chips
- auto-load current month for Cash Bictorys and Virement Mensuel
- Stock Soir: default date to yesterday, hide montant-debut-mois menu entry, uniformize colors (drop green title/banner, ghost action buttons)
- anti-FOUC: full-screen banking-style loader with double-ring spinner, body.nav-ready reveal after first paint
- theme toggle button auto-injected, color-scheme CSS for native controls
- additional dark mode coverage on remaining containers
- visualisation: default dates to first-of-month -> today

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global loading overlay during app startup
  * New Créances multi-account mode and global cross-account view with filters, exclusions, summary cards and per-client aggregates

* **Bug Fixes**
  * More robust sidebar readiness handling and fail-safe to avoid stuck UI
  * Stock date input now defaults to yesterday; several auto-loads made non-blocking with graceful warnings
  * One sidebar menu entry is now shown as disabled

* **Style**
  * Improved light/dark theming and UI refinements for Stock and Créances

* **Chores**
  * Preprod startup scripts now require external environment variables instead of hardcoded credentials

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zalint/MATA_DEPENSES_MANAGEMENT/pull/38)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->