### PR TITLE
distinguish Avance vs Remboursement visually in operations history

### DIFF
--- a/create_comptable_documents_table.sql
+++ b/create_comptable_documents_table.sql
@@ -1,0 +1,23 @@
+-- ===================================================
+-- Table : comptable_documents
+-- Stocke les métadonnées des documents comptables uploadés
+-- (factures, justificatifs, états, etc.) accessibles depuis
+-- Config > Documents comptables. Les fichiers physiques sont
+-- conservés sur le disque dans uploads/comptable/{year}/.
+-- ===================================================
+CREATE TABLE IF NOT EXISTS comptable_documents (
+    id SERIAL PRIMARY KEY,
+    libelle VARCHAR(255) NOT NULL,
+    year INTEGER NOT NULL CHECK (year BETWEEN 2000 AND 2100),
+    original_filename VARCHAR(500),
+    stored_path TEXT NOT NULL,
+    mime_type VARCHAR(100),
+    size_bytes BIGINT,
+    uploaded_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    uploaded_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_comptable_documents_year
+    ON comptable_documents(year);
+CREATE INDEX IF NOT EXISTS idx_comptable_documents_uploaded_at
+    ON comptable_documents(uploaded_at DESC);

--- a/public/app.js
+++ b/public/app.js
@@ -14297,6 +14297,14 @@ function setupConfigTabs() {
                 document.getElementById('stock-permissions-config').classList.add('active');
                 // Initialiser les permissions lorsque l'onglet est activé
                 initStockVivantPermissions();
+            } else if (configType === 'invoice-template') {
+                document.getElementById('invoice-template-config').classList.add('active');
+                // Charger les 2 configs à l'ouverture de l'onglet (lazy)
+                if (typeof loadInvoiceTemplate === 'function') loadInvoiceTemplate();
+                if (typeof loadCreanceTemplate === 'function') loadCreanceTemplate();
+            } else if (configType === 'comptable-docs') {
+                document.getElementById('comptable-docs-config').classList.add('active');
+                if (typeof initComptableDocsModule === 'function') initComptableDocsModule();
             }
         });
     });
@@ -15773,6 +15781,42 @@ function renderCreanceGlobalResults(data) {
             if (creanceGlobalLastData) renderCreanceGlobalResults(creanceGlobalLastData);
         });
     });
+
+    // Handler : génération facture pour UN client (bouton par ligne)
+    resultsEl.querySelectorAll('.qw-btn-creance-invoice').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const clientName = btn.getAttribute('data-client-name') || '';
+            if (!clientName) return;
+            openCreanceInvoicePdf({ clientName });
+        });
+    });
+
+    // Handler : génération facture pour TOUS les clients (bouton en haut)
+    const allBtn = resultsEl.querySelector('#qw-btn-creance-invoice-all');
+    if (allBtn) {
+        allBtn.addEventListener('click', () => openCreanceInvoicePdf({ clientName: null }));
+    }
+}
+
+/**
+ * Ouvre le PDF de facture(s) créance dans un nouvel onglet.
+ * - clientName=null  -> batch tous clients (avec exclusions courantes)
+ * - clientName=X     -> 1 seul client (les exclusions sont alors ignorées
+ *   car l'utilisateur a explicitement cliqué sur ce client)
+ */
+function openCreanceInvoicePdf({ clientName }) {
+    const summary = (creanceGlobalLastData && creanceGlobalLastData.summary) || {};
+    const dateSelected = summary.date_selected || new Date().toISOString().split('T')[0];
+    const params = new URLSearchParams();
+    params.set('date', dateSelected);
+    if (clientName) {
+        params.set('client_name', clientName);
+    } else if (creanceGlobalExclusions && creanceGlobalExclusions.length > 0) {
+        // Pour le batch, on respecte les exclusions courantes de la vue
+        params.set('exclusionClients', creanceGlobalExclusions.join(';'));
+    }
+    const url = `/api/creance/global/invoice-pdf?${params.toString()}`;
+    window.open(url, '_blank', 'noopener');
 }
 
 /**
@@ -15890,6 +15934,13 @@ function renderCreanceGlobalByClient(data) {
         return `<span class="qw-amount ${cls}">${fmt(v)}</span>`;
     };
 
+    // Bouton "Facture" par ligne : ouvre /api/creance/global/invoice-pdf?client_name=X
+    const invoiceBtn = (clientName) => `
+        <button type="button" class="btn btn-sm btn-secondary qw-btn-creance-invoice"
+                data-client-name="${escapeHtml(clientName)}" title="Générer la facture MATA pour ce client">
+            <i class="fas fa-file-invoice"></i> Facture
+        </button>`;
+
     // Tableau pour la Partie 1
     const renderActifsTable = () => `
         <div class="table-container" style="margin-bottom: 18px;">
@@ -15903,6 +15954,7 @@ function renderCreanceGlobalByClient(data) {
                         <th>Dernière avance</th>
                         <th>Compte</th>
                         <th>Activité</th>
+                        <th style="width: 110px;">Action</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -15915,6 +15967,7 @@ function renderCreanceGlobalByClient(data) {
                             <td>${datePill(c.lastAvance, false)}</td>
                             <td>${portfolioBadge(c.portfolio)}</td>
                             <td>${stalenessPill(c)}</td>
+                            <td>${invoiceBtn(c.name)}</td>
                         </tr>
                     `).join('')}
                 </tbody>
@@ -15931,6 +15984,7 @@ function renderCreanceGlobalByClient(data) {
                         <th>Client</th>
                         <th style="text-align: right;">Solde</th>
                         <th>Compte</th>
+                        <th style="width: 110px;">Action</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -15940,6 +15994,7 @@ function renderCreanceGlobalByClient(data) {
                             <td><strong>${escapeHtml(c.name)}</strong></td>
                             <td style="text-align: right;">${soldeCell(c.solde)}</td>
                             <td>${portfolioBadge(c.portfolio)}</td>
+                            <td>${invoiceBtn(c.name)}</td>
                         </tr>
                     `).join('')}
                 </tbody>
@@ -15947,6 +16002,18 @@ function renderCreanceGlobalByClient(data) {
         </div>`;
 
     return `
+        <!-- Barre d'actions : génération de factures MATA (ancien format) -->
+        <div class="qw-client-actions-bar">
+            <button type="button" id="qw-btn-creance-invoice-all" class="btn btn-primary"
+                    title="Générer un PDF avec une facture MATA par client (page A4 par client)">
+                <i class="fas fa-file-invoice"></i> Générer toutes les factures (${allClients.length})
+            </button>
+            <span class="qw-client-actions-hint">
+                Factures au format MATA, 1 page par client. Modèle modifiable depuis
+                <strong>Config &gt; Modèle de facture &gt; Facture Créance</strong>.
+            </span>
+        </div>
+
         <!-- Récap mini-stats par client -->
         <div class="qw-client-summary">
             <div class="qw-client-summary-item">
@@ -20693,4 +20760,880 @@ function updateValidationStatusUI(statusData) {
         message.textContent = 'Validation des dépenses désactivée';
         details.textContent = 'Les dépenses peuvent dépasser le solde du compte - Mode libre activé';
     }
+}
+
+// =====================================================
+// MODULE : Modèle de facture (admin)
+// =====================================================
+// Onglet "Modèle de facture" dans la section Admin Config.
+// - Charge GET /api/invoice-template (alias + profils)
+// - Permet d'ajouter/modifier/supprimer en place dans 2 tableaux
+// - Bouton "Aperçu" -> ouvre /api/invoice-template/preview dans un onglet
+// - Bouton "Enregistrer" -> PUT vers /api/invoice-template
+// État local pour permettre l'annulation sans refetch immédiat.
+let invoiceTemplateState = { aliases: {}, profiles: {}, defaults: { aliases: {}, profiles: {} }, dirty: false };
+let invoiceTemplateListenersAttached = false;
+
+function setInvoiceTemplateStatus(text, kind) {
+    const el = document.getElementById('invoice-template-status');
+    if (!el) return;
+    el.textContent = text || '';
+    el.className = 'qw-invoice-status' + (kind ? ' qw-invoice-status-' + kind : '');
+}
+function markInvoiceTemplateDirty(isDirty) {
+    invoiceTemplateState.dirty = isDirty;
+    setInvoiceTemplateStatus(isDirty ? 'Modifications non enregistrées' : '', isDirty ? 'pending' : '');
+}
+
+async function loadInvoiceTemplate() {
+    attachInvoiceTemplateListenersOnce();
+    setInvoiceTemplateStatus('Chargement…', '');
+    try {
+        const r = await fetch('/api/invoice-template');
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const data = await r.json();
+        invoiceTemplateState.aliases = Object.assign({}, data.aliases || {});
+        invoiceTemplateState.profiles = JSON.parse(JSON.stringify(data.profiles || {}));
+        invoiceTemplateState.defaults = data.defaults || { aliases: {}, profiles: {} };
+        renderInvoiceTemplateTables();
+        markInvoiceTemplateDirty(false);
+        setInvoiceTemplateStatus('Configuration chargée.', 'ok');
+        setTimeout(() => { if (!invoiceTemplateState.dirty) setInvoiceTemplateStatus('', ''); }, 2000);
+    } catch (err) {
+        console.error('Erreur chargement /api/invoice-template:', err);
+        setInvoiceTemplateStatus('Erreur de chargement : ' + (err.message || err), 'error');
+    }
+}
+
+function renderInvoiceTemplateTables() {
+    renderInvoiceProfilesTable();
+    renderInvoiceAliasesTable();
+}
+
+function renderInvoiceProfilesTable() {
+    const tbody = document.getElementById('invoice-profiles-tbody');
+    if (!tbody) return;
+    const entries = Object.entries(invoiceTemplateState.profiles);
+    if (entries.length === 0) {
+        tbody.innerHTML = `<tr><td colspan="5" style="text-align: center; color: var(--qw-text-secondary);">Aucun profil. Cliquez sur "Ajouter un profil" pour en créer un.</td></tr>`;
+        return;
+    }
+    tbody.innerHTML = entries.map(([canonical, p]) => `
+        <tr data-canonical="${escapeHtml(canonical)}">
+            <td><input type="text" class="form-control qw-inp-canonical" value="${escapeHtml(canonical)}" maxlength="120"></td>
+            <td><input type="text" class="form-control qw-inp-display" value="${escapeHtml(p.displayName || '')}" maxlength="120" placeholder="ex. Aly Ka, marchand de bétail"></td>
+            <td><input type="text" class="form-control qw-inp-location" value="${escapeHtml(p.location || '')}" maxlength="120" placeholder="ex. Foirail de Sicap Mbao"></td>
+            <td><input type="text" class="form-control qw-inp-phone" value="${escapeHtml(p.phone || '')}" maxlength="40" placeholder="ex. 778625595"></td>
+            <td>
+                <button type="button" class="btn btn-danger btn-sm qw-btn-del-profile" title="Supprimer ce profil">
+                    <i class="fas fa-trash"></i>
+                </button>
+            </td>
+        </tr>
+    `).join('');
+
+    // Listeners
+    tbody.querySelectorAll('tr').forEach(tr => {
+        tr.querySelectorAll('input').forEach(inp => {
+            inp.addEventListener('input', () => collectProfilesFromTable());
+        });
+        tr.querySelector('.qw-btn-del-profile').addEventListener('click', () => {
+            tr.remove();
+            collectProfilesFromTable();
+            if (Object.keys(invoiceTemplateState.profiles).length === 0) renderInvoiceProfilesTable();
+        });
+    });
+}
+
+function collectProfilesFromTable() {
+    const tbody = document.getElementById('invoice-profiles-tbody');
+    if (!tbody) return;
+    const next = {};
+    tbody.querySelectorAll('tr').forEach(tr => {
+        const canonicalInput = tr.querySelector('.qw-inp-canonical');
+        if (!canonicalInput) return;
+        const canonical = canonicalInput.value.trim();
+        if (!canonical) return;
+        next[canonical] = {
+            displayName: tr.querySelector('.qw-inp-display').value.trim(),
+            location: tr.querySelector('.qw-inp-location').value.trim(),
+            phone: tr.querySelector('.qw-inp-phone').value.trim()
+        };
+    });
+    invoiceTemplateState.profiles = next;
+    markInvoiceTemplateDirty(true);
+}
+
+function renderInvoiceAliasesTable() {
+    const tbody = document.getElementById('invoice-aliases-tbody');
+    if (!tbody) return;
+    const entries = Object.entries(invoiceTemplateState.aliases);
+    if (entries.length === 0) {
+        tbody.innerHTML = `<tr><td colspan="3" style="text-align: center; color: var(--qw-text-secondary);">Aucun alias. Cliquez sur "Ajouter un alias" pour en créer un.</td></tr>`;
+        return;
+    }
+    tbody.innerHTML = entries.map(([alias, canonical]) => `
+        <tr>
+            <td><input type="text" class="form-control qw-inp-alias" value="${escapeHtml(alias)}" maxlength="120" placeholder="ex. aly ka"></td>
+            <td><input type="text" class="form-control qw-inp-alias-canonical" value="${escapeHtml(canonical)}" maxlength="120" placeholder="ex. Ali KA"></td>
+            <td>
+                <button type="button" class="btn btn-danger btn-sm qw-btn-del-alias" title="Supprimer cet alias">
+                    <i class="fas fa-trash"></i>
+                </button>
+            </td>
+        </tr>
+    `).join('');
+
+    tbody.querySelectorAll('tr').forEach(tr => {
+        tr.querySelectorAll('input').forEach(inp => {
+            inp.addEventListener('input', () => collectAliasesFromTable());
+        });
+        tr.querySelector('.qw-btn-del-alias').addEventListener('click', () => {
+            tr.remove();
+            collectAliasesFromTable();
+            if (Object.keys(invoiceTemplateState.aliases).length === 0) renderInvoiceAliasesTable();
+        });
+    });
+}
+
+function collectAliasesFromTable() {
+    const tbody = document.getElementById('invoice-aliases-tbody');
+    if (!tbody) return;
+    const next = {};
+    tbody.querySelectorAll('tr').forEach(tr => {
+        const aliasInput = tr.querySelector('.qw-inp-alias');
+        const canonicalInput = tr.querySelector('.qw-inp-alias-canonical');
+        if (!aliasInput || !canonicalInput) return;
+        const alias = aliasInput.value.trim().toLowerCase().replace(/\s+/g, ' ');
+        const canonical = canonicalInput.value.trim();
+        if (!alias || !canonical) return;
+        next[alias] = canonical;
+    });
+    invoiceTemplateState.aliases = next;
+    markInvoiceTemplateDirty(true);
+}
+
+function addEmptyInvoiceProfileRow() {
+    const tbody = document.getElementById('invoice-profiles-tbody');
+    if (!tbody) return;
+    // Si le tbody contient seulement le placeholder, on le nettoie
+    if (tbody.querySelector('td[colspan]')) tbody.innerHTML = '';
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+        <td><input type="text" class="form-control qw-inp-canonical" value="" maxlength="120" placeholder="ex. Mamadou DIOP"></td>
+        <td><input type="text" class="form-control qw-inp-display" value="" maxlength="120" placeholder="ex. Mamadou Diop, boucher"></td>
+        <td><input type="text" class="form-control qw-inp-location" value="" maxlength="120" placeholder="ex. Marché Sandaga"></td>
+        <td><input type="text" class="form-control qw-inp-phone" value="" maxlength="40" placeholder="ex. 776543210"></td>
+        <td>
+            <button type="button" class="btn btn-danger btn-sm qw-btn-del-profile" title="Supprimer ce profil">
+                <i class="fas fa-trash"></i>
+            </button>
+        </td>`;
+    tbody.appendChild(tr);
+    tr.querySelectorAll('input').forEach(inp => inp.addEventListener('input', () => collectProfilesFromTable()));
+    tr.querySelector('.qw-btn-del-profile').addEventListener('click', () => {
+        tr.remove();
+        collectProfilesFromTable();
+        if (Object.keys(invoiceTemplateState.profiles).length === 0) renderInvoiceProfilesTable();
+    });
+    tr.querySelector('.qw-inp-canonical').focus();
+}
+
+function addEmptyInvoiceAliasRow() {
+    const tbody = document.getElementById('invoice-aliases-tbody');
+    if (!tbody) return;
+    if (tbody.querySelector('td[colspan]')) tbody.innerHTML = '';
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+        <td><input type="text" class="form-control qw-inp-alias" value="" maxlength="120" placeholder="ex. aly ka"></td>
+        <td><input type="text" class="form-control qw-inp-alias-canonical" value="" maxlength="120" placeholder="ex. Ali KA"></td>
+        <td>
+            <button type="button" class="btn btn-danger btn-sm qw-btn-del-alias" title="Supprimer cet alias">
+                <i class="fas fa-trash"></i>
+            </button>
+        </td>`;
+    tbody.appendChild(tr);
+    tr.querySelectorAll('input').forEach(inp => inp.addEventListener('input', () => collectAliasesFromTable()));
+    tr.querySelector('.qw-btn-del-alias').addEventListener('click', () => {
+        tr.remove();
+        collectAliasesFromTable();
+        if (Object.keys(invoiceTemplateState.aliases).length === 0) renderInvoiceAliasesTable();
+    });
+    tr.querySelector('.qw-inp-alias').focus();
+}
+
+async function saveInvoiceTemplate() {
+    collectProfilesFromTable();
+    collectAliasesFromTable();
+    setInvoiceTemplateStatus('Enregistrement…', 'pending');
+    try {
+        const r = await fetch('/api/invoice-template', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                aliases: invoiceTemplateState.aliases,
+                profiles: invoiceTemplateState.profiles
+            })
+        });
+        if (!r.ok) {
+            const txt = await r.text();
+            throw new Error('HTTP ' + r.status + ' — ' + txt.slice(0, 200));
+        }
+        const data = await r.json();
+        invoiceTemplateState.aliases = data.aliases || {};
+        invoiceTemplateState.profiles = data.profiles || {};
+        renderInvoiceTemplateTables();
+        markInvoiceTemplateDirty(false);
+        setInvoiceTemplateStatus('Modifications enregistrées.', 'ok');
+        if (typeof showNotification === 'function') showNotification('Modèle de facture enregistré', 'success');
+    } catch (err) {
+        console.error('Erreur PUT /api/invoice-template:', err);
+        setInvoiceTemplateStatus('Erreur : ' + (err.message || err), 'error');
+        if (typeof showNotification === 'function') showNotification('Erreur lors de l\'enregistrement du modèle de facture', 'error');
+    }
+}
+
+async function openInvoicePreview() {
+    const supplierInput = document.getElementById('invoice-preview-supplier');
+    const supplier = (supplierInput && supplierInput.value || '').trim();
+    // Si l'utilisateur a fait des modifs non sauvegardées, prévenir
+    // via le modal moderne (pas de confirm() natif).
+    if (invoiceTemplateState.dirty) {
+        const proceed = await confirmModal({
+            title: 'Modifications non enregistrées',
+            message: "Tu as des modifications non enregistrées dans le modèle. L'aperçu utilise la version actuellement <strong>sauvegardée en base</strong>, pas tes modifications en cours. Continuer quand même ?",
+            okLabel: 'Continuer',
+            cancelLabel: 'Annuler'
+        });
+        if (!proceed) return;
+    }
+    const params = new URLSearchParams();
+    if (supplier) params.set('supplier', supplier);
+    const url = '/api/invoice-template/preview' + (params.toString() ? ('?' + params.toString()) : '');
+    window.open(url, '_blank', 'noopener');
+}
+
+function attachInvoiceTemplateListenersOnce() {
+    if (invoiceTemplateListenersAttached) return;
+    const saveBtn = document.getElementById('invoice-template-save-btn');
+    const reloadBtn = document.getElementById('invoice-template-reload-btn');
+    const previewBtn = document.getElementById('invoice-preview-btn');
+    const addProfileBtn = document.getElementById('invoice-add-profile-btn');
+    const addAliasBtn = document.getElementById('invoice-add-alias-btn');
+    const supplierInput = document.getElementById('invoice-preview-supplier');
+    if (saveBtn) saveBtn.addEventListener('click', saveInvoiceTemplate);
+    if (reloadBtn) reloadBtn.addEventListener('click', loadInvoiceTemplate);
+    if (previewBtn) previewBtn.addEventListener('click', openInvoicePreview);
+    if (addProfileBtn) addProfileBtn.addEventListener('click', addEmptyInvoiceProfileRow);
+    if (addAliasBtn) addAliasBtn.addEventListener('click', addEmptyInvoiceAliasRow);
+    if (supplierInput) {
+        supplierInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                openInvoicePreview();
+            }
+        });
+    }
+    invoiceTemplateListenersAttached = true;
+}
+
+// =====================================================
+// MODULE : Modèle de FACTURE CRÉANCE (ancien format MATA)
+// =====================================================
+// Formulaire dans le même onglet "Modèle de facture" sous le bloc
+// supplier templates. Charge GET /api/invoice-creance-template,
+// permet d'éditer + Enregistrer (PUT) + Aperçu (ouverture PDF).
+const CREANCE_TPL_FIELDS = [
+    { key: 'company_name',   id: 'creance-tpl-company' },
+    { key: 'address_line_1', id: 'creance-tpl-addr1' },
+    { key: 'address_line_2', id: 'creance-tpl-addr2' },
+    { key: 'address_line_3', id: 'creance-tpl-addr3' },
+    { key: 'address_line_4', id: 'creance-tpl-addr4' },
+    { key: 'designation',    id: 'creance-tpl-designation' },
+    { key: 'categories',     id: 'creance-tpl-categories' },
+    { key: 'title_color',    id: 'creance-tpl-color' }
+];
+let creanceTemplateState = { data: {}, dirty: false };
+let creanceTemplateListenersAttached = false;
+
+function setCreanceTemplateStatus(text, kind) {
+    const el = document.getElementById('creance-tpl-status');
+    if (!el) return;
+    el.textContent = text || '';
+    el.className = 'qw-invoice-status' + (kind ? ' qw-invoice-status-' + kind : '');
+}
+function markCreanceTemplateDirty(isDirty) {
+    creanceTemplateState.dirty = isDirty;
+    setCreanceTemplateStatus(isDirty ? 'Modifications non enregistrées' : '', isDirty ? 'pending' : '');
+}
+
+async function loadCreanceTemplate() {
+    attachCreanceTemplateListenersOnce();
+    setCreanceTemplateStatus('Chargement…', '');
+    try {
+        const r = await fetch('/api/invoice-creance-template');
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const data = await r.json();
+        creanceTemplateState.data = data || {};
+        // Remplir les inputs
+        CREANCE_TPL_FIELDS.forEach(f => {
+            const el = document.getElementById(f.id);
+            if (el) el.value = (data && data[f.key]) || '';
+        });
+        // Sync color picker
+        const picker = document.getElementById('creance-tpl-color-picker');
+        if (picker) picker.value = (data && /^#[0-9a-fA-F]{6}$/.test(data.title_color || '')) ? data.title_color : '#1e3a8a';
+        markCreanceTemplateDirty(false);
+        setCreanceTemplateStatus('Configuration chargée.', 'ok');
+        setTimeout(() => { if (!creanceTemplateState.dirty) setCreanceTemplateStatus('', ''); }, 2000);
+    } catch (err) {
+        console.error('Erreur chargement /api/invoice-creance-template:', err);
+        setCreanceTemplateStatus('Erreur de chargement : ' + (err.message || err), 'error');
+    }
+}
+
+function collectCreanceTemplateFromForm() {
+    const out = {};
+    CREANCE_TPL_FIELDS.forEach(f => {
+        const el = document.getElementById(f.id);
+        if (el) out[f.key] = el.value.trim();
+    });
+    return out;
+}
+
+async function saveCreanceTemplate() {
+    const payload = collectCreanceTemplateFromForm();
+    // Validation soft côté client (le serveur revalide)
+    if (payload.title_color && !/^#[0-9a-fA-F]{6}$/.test(payload.title_color)) {
+        setCreanceTemplateStatus('Couleur invalide : utiliser #RRGGBB (6 caractères hex)', 'error');
+        return;
+    }
+    setCreanceTemplateStatus('Enregistrement…', 'pending');
+    try {
+        const r = await fetch('/api/invoice-creance-template', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        if (!r.ok) {
+            const txt = await r.text();
+            throw new Error('HTTP ' + r.status + ' — ' + txt.slice(0, 200));
+        }
+        const data = await r.json();
+        creanceTemplateState.data = data;
+        // Rafraîchir les valeurs (le serveur peut avoir trim/normalisé)
+        CREANCE_TPL_FIELDS.forEach(f => {
+            const el = document.getElementById(f.id);
+            if (el && data[f.key] !== undefined) el.value = data[f.key];
+        });
+        markCreanceTemplateDirty(false);
+        setCreanceTemplateStatus('Modèle créance enregistré.', 'ok');
+        if (typeof showNotification === 'function') showNotification('Modèle de facture créance enregistré', 'success');
+    } catch (err) {
+        console.error('Erreur PUT /api/invoice-creance-template:', err);
+        setCreanceTemplateStatus('Erreur : ' + (err.message || err), 'error');
+        if (typeof showNotification === 'function') showNotification('Erreur lors de l\'enregistrement du modèle créance', 'error');
+    }
+}
+
+async function openCreanceTemplatePreview() {
+    if (creanceTemplateState.dirty) {
+        const proceed = await confirmModal({
+            title: 'Modifications non enregistrées',
+            message: "Tu as des modifications non enregistrées. L'aperçu utilise la version <strong>sauvegardée en base</strong>, pas tes modifications en cours. Continuer ?",
+            okLabel: 'Continuer',
+            cancelLabel: 'Annuler'
+        });
+        if (!proceed) return;
+    }
+    window.open('/api/invoice-creance-template/preview', '_blank', 'noopener');
+}
+
+function attachCreanceTemplateListenersOnce() {
+    if (creanceTemplateListenersAttached) return;
+    // Inputs texte -> dirty
+    CREANCE_TPL_FIELDS.forEach(f => {
+        const el = document.getElementById(f.id);
+        if (el) el.addEventListener('input', () => markCreanceTemplateDirty(true));
+    });
+    // Color picker <-> color text input synchronisés
+    const picker = document.getElementById('creance-tpl-color-picker');
+    const colorInput = document.getElementById('creance-tpl-color');
+    if (picker && colorInput) {
+        picker.addEventListener('input', () => {
+            colorInput.value = picker.value;
+            markCreanceTemplateDirty(true);
+        });
+        colorInput.addEventListener('input', () => {
+            if (/^#[0-9a-fA-F]{6}$/.test(colorInput.value)) picker.value = colorInput.value;
+            markCreanceTemplateDirty(true);
+        });
+    }
+    // Boutons
+    const saveBtn = document.getElementById('creance-tpl-save-btn');
+    const reloadBtn = document.getElementById('creance-tpl-reload-btn');
+    const previewBtn = document.getElementById('creance-tpl-preview-btn');
+    if (saveBtn) saveBtn.addEventListener('click', saveCreanceTemplate);
+    if (reloadBtn) reloadBtn.addEventListener('click', loadCreanceTemplate);
+    if (previewBtn) previewBtn.addEventListener('click', openCreanceTemplatePreview);
+    creanceTemplateListenersAttached = true;
+}
+
+// =====================================================
+// MODULE : Documents comptables
+// =====================================================
+// Onglet "Documents comptables" dans Config. Verrouillé par mot de passe
+// partagé (configurable par admin/DG/PCA). TTL de 30 min d'inactivité.
+let comptableState = {
+    listenersAttached: false,
+    passwordSet: false,
+    unlocked: false,
+    ttlIntervalId: null,
+    ttlDeadline: 0,
+    currentYear: new Date().getFullYear()
+};
+
+function setComptablePwdStatus(text, kind) {
+    const el = document.getElementById('comptable-pwd-status');
+    if (!el) return;
+    el.textContent = text || '';
+    el.className = 'qw-invoice-status' + (kind ? ' qw-invoice-status-' + kind : '');
+}
+function setComptableUploadStatus(text, kind) {
+    const el = document.getElementById('comptable-upload-status');
+    if (!el) return;
+    el.textContent = text || '';
+    el.className = 'qw-invoice-status' + (kind ? ' qw-invoice-status-' + kind : '');
+}
+function setComptableUnlockError(text) {
+    const el = document.getElementById('comptable-unlock-error');
+    if (el) el.textContent = text || '';
+}
+
+function formatFileSize(bytes) {
+    const n = parseFloat(bytes) || 0;
+    if (n < 1024) return n + ' o';
+    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' Ko';
+    if (n < 1024 * 1024 * 1024) return (n / (1024 * 1024)).toFixed(1) + ' Mo';
+    return (n / (1024 * 1024 * 1024)).toFixed(2) + ' Go';
+}
+
+async function initComptableDocsModule() {
+    attachComptableListenersOnce();
+    // Pré-remplir année courante dans l'upload et le filtre
+    const now = new Date().getFullYear();
+    const yearInput = document.getElementById('comptable-upload-year');
+    if (yearInput && !yearInput.value) yearInput.value = now;
+    populateComptableYearFilter();
+    await refreshComptableStatus();
+}
+
+function populateComptableYearFilter() {
+    const sel = document.getElementById('comptable-filter-year');
+    if (!sel || sel.options.length > 0) return;
+    const currentYear = new Date().getFullYear();
+    // 10 années en arrière + 2 en avant
+    const years = [];
+    for (let y = currentYear + 2; y >= currentYear - 10; y--) years.push(y);
+    sel.innerHTML = years.map(y => `<option value="${y}" ${y === currentYear ? 'selected' : ''}>${y}</option>`).join('');
+    comptableState.currentYear = currentYear;
+}
+
+async function refreshComptableStatus() {
+    try {
+        const r = await fetch('/api/comptable/status');
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const data = await r.json();
+        comptableState.passwordSet = !!data.password_set;
+        comptableState.unlocked = !!data.unlocked;
+        updateComptablePwdStateBadge();
+        if (comptableState.unlocked) {
+            comptableState.ttlDeadline = Date.now() + (data.expires_in_ms || 0);
+            showComptableMainView();
+        } else {
+            showComptableLockScreen();
+        }
+    } catch (err) {
+        console.error('Erreur GET /api/comptable/status:', err);
+        showComptableLockScreen();
+        setComptableUnlockError('Erreur de chargement du statut : ' + (err.message || err));
+    }
+}
+
+function updateComptablePwdStateBadge() {
+    const badge = document.getElementById('comptable-pwd-state');
+    const currentWrap = document.getElementById('comptable-pwd-current-wrap');
+    if (!badge) return;
+    if (comptableState.passwordSet) {
+        badge.textContent = 'État : mot de passe défini';
+        badge.className = 'qw-pill qw-pill-success';
+        if (currentWrap) currentWrap.style.display = '';
+    } else {
+        badge.textContent = 'État : aucun mot de passe configuré';
+        badge.className = 'qw-pill qw-pill-warning';
+        if (currentWrap) currentWrap.style.display = 'none';
+    }
+}
+
+function showComptableLockScreen() {
+    const lock = document.getElementById('comptable-lock-screen');
+    const main = document.getElementById('comptable-main');
+    if (lock) lock.style.display = '';
+    if (main) main.style.display = 'none';
+    // Adapter le message selon que le mot de passe est défini ou pas
+    const msg = document.getElementById('comptable-lock-msg');
+    if (msg) {
+        msg.textContent = comptableState.passwordSet
+            ? "Cette section est verrouillée par un mot de passe partagé."
+            : "Aucun mot de passe n'a encore été configuré pour cette section. Demandez à un administrateur de le définir.";
+    }
+    const input = document.getElementById('comptable-unlock-pwd');
+    const btn = document.getElementById('comptable-unlock-btn');
+    if (input) input.disabled = !comptableState.passwordSet;
+    if (btn) btn.disabled = !comptableState.passwordSet;
+    stopComptableTtlCountdown();
+}
+
+function showComptableMainView() {
+    const lock = document.getElementById('comptable-lock-screen');
+    const main = document.getElementById('comptable-main');
+    if (lock) lock.style.display = 'none';
+    if (main) main.style.display = '';
+    setComptableUnlockError('');
+    startComptableTtlCountdown();
+    loadComptableDocuments();
+}
+
+function startComptableTtlCountdown() {
+    stopComptableTtlCountdown();
+    const tick = () => {
+        const ms = Math.max(0, comptableState.ttlDeadline - Date.now());
+        const el = document.getElementById('comptable-ttl-remaining');
+        if (el) {
+            const totalSec = Math.floor(ms / 1000);
+            const m = Math.floor(totalSec / 60);
+            const s = totalSec % 60;
+            el.textContent = `${m}:${String(s).padStart(2, '0')}`;
+        }
+        if (ms <= 0) {
+            comptableState.unlocked = false;
+            stopComptableTtlCountdown();
+            showComptableLockScreen();
+        }
+    };
+    tick();
+    comptableState.ttlIntervalId = setInterval(tick, 1000);
+}
+function stopComptableTtlCountdown() {
+    if (comptableState.ttlIntervalId) {
+        clearInterval(comptableState.ttlIntervalId);
+        comptableState.ttlIntervalId = null;
+    }
+}
+
+async function unlockComptable() {
+    const input = document.getElementById('comptable-unlock-pwd');
+    const pwd = input ? input.value : '';
+    if (!pwd) {
+        setComptableUnlockError('Mot de passe requis.');
+        return;
+    }
+    setComptableUnlockError('');
+    try {
+        const r = await fetch('/api/comptable/unlock', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password: pwd })
+        });
+        if (!r.ok) {
+            const data = await r.json().catch(() => ({}));
+            throw new Error(data.error || ('HTTP ' + r.status));
+        }
+        const data = await r.json();
+        comptableState.unlocked = true;
+        comptableState.ttlDeadline = Date.now() + (data.expires_in_ms || 0);
+        if (input) input.value = '';
+        showComptableMainView();
+    } catch (err) {
+        setComptableUnlockError(err.message || 'Erreur de déverrouillage');
+    }
+}
+
+async function lockComptable() {
+    try { await fetch('/api/comptable/lock', { method: 'POST' }); } catch (_) {}
+    comptableState.unlocked = false;
+    showComptableLockScreen();
+}
+
+async function loadComptableDocuments() {
+    const tbody = document.getElementById('comptable-docs-tbody');
+    const sel = document.getElementById('comptable-filter-year');
+    if (!tbody || !sel) return;
+    const year = parseInt(sel.value, 10) || new Date().getFullYear();
+    comptableState.currentYear = year;
+    tbody.innerHTML = `<tr><td colspan="7" style="text-align: center; color: var(--qw-text-secondary);">Chargement…</td></tr>`;
+    try {
+        const r = await fetch('/api/comptable/documents?year=' + encodeURIComponent(year));
+        if (r.status === 423) {
+            comptableState.unlocked = false;
+            showComptableLockScreen();
+            return;
+        }
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const docs = await r.json();
+        if (!docs || docs.length === 0) {
+            tbody.innerHTML = `<tr><td colspan="7" style="text-align: center; color: var(--qw-text-secondary);">Aucun document pour ${year}</td></tr>`;
+            return;
+        }
+        tbody.innerHTML = docs.map(d => `
+            <tr data-doc-id="${d.id}">
+                <td><strong>${escapeHtml(d.libelle || '')}</strong></td>
+                <td>${d.year}</td>
+                <td>
+                    <span title="${escapeHtml(d.original_filename || '')}" style="color: var(--qw-text-secondary); font-size: 12px;">
+                        ${escapeHtml((d.original_filename || '').slice(0, 50))}
+                    </span>
+                </td>
+                <td>${formatFileSize(d.size_bytes)}</td>
+                <td>${d.uploaded_at ? new Date(d.uploaded_at).toLocaleString('fr-FR') : ''}</td>
+                <td>${escapeHtml(d.uploaded_by_name || '')}</td>
+                <td>
+                    <a href="/api/comptable/documents/${d.id}/download" target="_blank" rel="noopener" class="btn btn-secondary btn-sm" title="Télécharger / Voir">
+                        <i class="fas fa-download"></i>
+                    </a>
+                    <button type="button" class="btn btn-danger btn-sm qw-btn-delete-comptable-doc" data-doc-id="${d.id}" data-libelle="${escapeHtml(d.libelle || '')}" title="Supprimer">
+                        <i class="fas fa-trash"></i>
+                    </button>
+                </td>
+            </tr>
+        `).join('');
+        // Attach delete handlers
+        tbody.querySelectorAll('.qw-btn-delete-comptable-doc').forEach(btn => {
+            btn.addEventListener('click', () => deleteComptableDocument(btn));
+        });
+    } catch (err) {
+        tbody.innerHTML = `<tr><td colspan="7" style="text-align: center; color: var(--qw-text-secondary);">Erreur : ${escapeHtml(err.message || String(err))}</td></tr>`;
+    }
+}
+
+async function uploadComptableDocument(event) {
+    event.preventDefault();
+    const fileInput = document.getElementById('comptable-upload-file');
+    const libelleInput = document.getElementById('comptable-upload-libelle');
+    const yearInput = document.getElementById('comptable-upload-year');
+    if (!fileInput || !libelleInput || !yearInput) return;
+    if (!fileInput.files || fileInput.files.length === 0) {
+        setComptableUploadStatus('Sélectionne un fichier.', 'error');
+        return;
+    }
+    const file = fileInput.files[0];
+    const MAX = 50 * 1024 * 1024;
+    if (file.size > MAX) {
+        setComptableUploadStatus('Fichier trop volumineux (max 50 Mo).', 'error');
+        return;
+    }
+    const libelle = libelleInput.value.trim();
+    const year = parseInt(yearInput.value, 10);
+    if (!libelle) {
+        setComptableUploadStatus('Libellé requis.', 'error');
+        return;
+    }
+    if (!year || year < 2000 || year > 2100) {
+        setComptableUploadStatus('Année invalide.', 'error');
+        return;
+    }
+    setComptableUploadStatus('Téléversement en cours…', 'pending');
+    try {
+        const fd = new FormData();
+        fd.append('libelle', libelle);
+        fd.append('year', String(year));
+        fd.append('file', file);
+        const r = await fetch('/api/comptable/documents', { method: 'POST', body: fd });
+        if (r.status === 423) {
+            comptableState.unlocked = false;
+            showComptableLockScreen();
+            return;
+        }
+        if (!r.ok) {
+            const data = await r.json().catch(() => ({}));
+            throw new Error(data.error || ('HTTP ' + r.status));
+        }
+        await r.json();
+        setComptableUploadStatus('Document téléversé.', 'ok');
+        fileInput.value = '';
+        libelleInput.value = '';
+        // Si l'année uploadée n'est pas l'année du filtre, on la sélectionne
+        const sel = document.getElementById('comptable-filter-year');
+        if (sel && parseInt(sel.value, 10) !== year) {
+            // Ajouter l'option si pas présente
+            if (![...sel.options].some(o => parseInt(o.value, 10) === year)) {
+                const opt = document.createElement('option');
+                opt.value = String(year);
+                opt.textContent = String(year);
+                sel.insertBefore(opt, sel.firstChild);
+            }
+            sel.value = String(year);
+        }
+        await loadComptableDocuments();
+        setTimeout(() => setComptableUploadStatus('', ''), 2000);
+    } catch (err) {
+        setComptableUploadStatus('Erreur : ' + (err.message || err), 'error');
+    }
+}
+
+async function deleteComptableDocument(btn) {
+    const docId = btn.getAttribute('data-doc-id');
+    const libelle = btn.getAttribute('data-libelle') || '';
+    if (!docId) return;
+    // Modal qui demande le mot de passe
+    const password = await promptComptableDeletePassword(libelle);
+    if (password === null) return; // annulé
+    try {
+        const r = await fetch('/api/comptable/documents/' + encodeURIComponent(docId), {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password })
+        });
+        if (r.status === 423) {
+            comptableState.unlocked = false;
+            showComptableLockScreen();
+            return;
+        }
+        if (!r.ok) {
+            const data = await r.json().catch(() => ({}));
+            throw new Error(data.error || ('HTTP ' + r.status));
+        }
+        if (typeof showNotification === 'function') showNotification('Document supprimé', 'success');
+        await loadComptableDocuments();
+    } catch (err) {
+        if (typeof showNotification === 'function') showNotification('Erreur : ' + (err.message || err), 'error');
+    }
+}
+
+/**
+ * Modal "Confirmer suppression" avec champ mot de passe. Réutilise les
+ * classes confirm-modal-* du modal partagé pour le style.
+ * Retourne le mot de passe saisi ou null si annulé.
+ */
+function promptComptableDeletePassword(libelle) {
+    return new Promise((resolve) => {
+        const overlay = document.createElement('div');
+        overlay.className = 'confirm-modal-overlay';
+        overlay.setAttribute('role', 'dialog');
+        overlay.setAttribute('aria-modal', 'true');
+        overlay.innerHTML = `
+            <div class="confirm-modal-dialog confirm-modal-danger">
+                <div class="confirm-modal-title">Confirmer la suppression</div>
+                <div class="confirm-modal-message">
+                    Vous êtes sur le point de supprimer définitivement le document :<br>
+                    <strong>${escapeHtml(libelle || 'ce document')}</strong>.<br>
+                    Pour confirmer, retapez le mot de passe d'accès.
+                </div>
+                <div class="form-group" style="margin: 10px 0 0;">
+                    <input type="password" id="qw-comptable-del-pwd" class="form-control" placeholder="Mot de passe d'accès" autocomplete="off">
+                    <small id="qw-comptable-del-err" style="color: #b91c1c; display: block; min-height: 16px;"></small>
+                </div>
+                <div class="confirm-modal-actions">
+                    <button type="button" class="btn btn-secondary confirm-modal-cancel" data-action="cancel">Annuler</button>
+                    <button type="button" class="btn btn-danger confirm-modal-ok" data-action="confirm">
+                        <i class="fas fa-trash"></i> Supprimer
+                    </button>
+                </div>
+            </div>`;
+        document.body.appendChild(overlay);
+        const pwdInput = overlay.querySelector('#qw-comptable-del-pwd');
+        const errSpan = overlay.querySelector('#qw-comptable-del-err');
+        setTimeout(() => pwdInput && pwdInput.focus(), 50);
+
+        const cleanup = () => {
+            try { document.body.removeChild(overlay); } catch (_) {}
+        };
+        const onCancel = () => { cleanup(); resolve(null); };
+        const onConfirm = () => {
+            const v = pwdInput ? pwdInput.value : '';
+            if (!v) {
+                if (errSpan) errSpan.textContent = 'Mot de passe requis.';
+                return;
+            }
+            cleanup();
+            resolve(v);
+        };
+        overlay.querySelector('[data-action="cancel"]').addEventListener('click', onCancel);
+        overlay.querySelector('[data-action="confirm"]').addEventListener('click', onConfirm);
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) onCancel(); });
+        pwdInput && pwdInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); onConfirm(); }
+            if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+        });
+    });
+}
+
+async function saveComptablePassword() {
+    const newPwd = document.getElementById('comptable-pwd-new');
+    const confirmPwd = document.getElementById('comptable-pwd-confirm');
+    const currentPwd = document.getElementById('comptable-pwd-current');
+    if (!newPwd || !confirmPwd) return;
+    const newVal = newPwd.value;
+    const confirmVal = confirmPwd.value;
+    if (!newVal || newVal.length < 6) {
+        setComptablePwdStatus('Le nouveau mot de passe doit faire au moins 6 caractères.', 'error');
+        return;
+    }
+    if (newVal !== confirmVal) {
+        setComptablePwdStatus('Les deux mots de passe ne correspondent pas.', 'error');
+        return;
+    }
+    setComptablePwdStatus('Enregistrement…', 'pending');
+    try {
+        const body = { newPassword: newVal };
+        if (comptableState.passwordSet && currentPwd && currentPwd.value) {
+            body.currentPassword = currentPwd.value;
+        }
+        const r = await fetch('/api/comptable/password', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+        if (!r.ok) {
+            const data = await r.json().catch(() => ({}));
+            throw new Error(data.error || ('HTTP ' + r.status));
+        }
+        setComptablePwdStatus('Mot de passe enregistré. Tous les utilisateurs devront re-déverrouiller.', 'ok');
+        newPwd.value = '';
+        confirmPwd.value = '';
+        if (currentPwd) currentPwd.value = '';
+        // Re-fetch status pour mettre à jour le badge + verrouiller la session courante
+        await refreshComptableStatus();
+    } catch (err) {
+        setComptablePwdStatus('Erreur : ' + (err.message || err), 'error');
+    }
+}
+
+function attachComptableListenersOnce() {
+    if (comptableState.listenersAttached) return;
+
+    const unlockBtn = document.getElementById('comptable-unlock-btn');
+    const unlockPwd = document.getElementById('comptable-unlock-pwd');
+    if (unlockBtn) unlockBtn.addEventListener('click', unlockComptable);
+    if (unlockPwd) {
+        unlockPwd.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); unlockComptable(); }
+        });
+    }
+
+    const lockBtn = document.getElementById('comptable-lock-btn');
+    if (lockBtn) lockBtn.addEventListener('click', lockComptable);
+
+    const uploadForm = document.getElementById('comptable-upload-form');
+    if (uploadForm) uploadForm.addEventListener('submit', uploadComptableDocument);
+
+    const refreshBtn = document.getElementById('comptable-refresh-btn');
+    const filterSel = document.getElementById('comptable-filter-year');
+    if (refreshBtn) refreshBtn.addEventListener('click', loadComptableDocuments);
+    if (filterSel) filterSel.addEventListener('change', loadComptableDocuments);
+
+    const pwdSaveBtn = document.getElementById('comptable-pwd-save-btn');
+    if (pwdSaveBtn) pwdSaveBtn.addEventListener('click', saveComptablePassword);
+
+    comptableState.listenersAttached = true;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -16339,33 +16339,38 @@ function updateOperationsHistoryTable(operations) {
     
     operations.forEach(operation => {
         const row = document.createElement('tr');
-        
-        const typeClass = operation.operation_type === 'credit' ? 'amount-positive' : 'amount-negative';
-        const typeText = operation.operation_type === 'credit' ? 'Avance (+)' : 'Remboursement (-)';
-        
+
+        const isCredit = operation.operation_type === 'credit';
+        // Pill colorée pour le type + classe d'aide pour la ligne entière
+        const typePill = isCredit
+            ? '<span class="qw-pill qw-pill-success qw-op-type-pill"><i class="fas fa-arrow-up"></i> Avance</span>'
+            : '<span class="qw-pill qw-pill-danger qw-op-type-pill"><i class="fas fa-arrow-down"></i> Remboursement</span>';
+        const amountClass = isCredit ? 'qw-op-amount-credit' : 'qw-op-amount-debit';
+        row.classList.add(isCredit ? 'qw-op-row-credit' : 'qw-op-row-debit');
+
         // Générer les boutons d'actions selon les permissions
         const actionsHtml = generateCreanceOperationActions(operation);
-        
+
         // Formater les dates
         const operationDate = formatDate(operation.operation_date);
         const timestamp = new Date(operation.timestamp_creation);
         const timestampDate = timestamp.toLocaleDateString('fr-FR');
-        const timestampTime = timestamp.toLocaleTimeString('fr-FR', { 
-            hour: '2-digit', 
-            minute: '2-digit' 
+        const timestampTime = timestamp.toLocaleTimeString('fr-FR', {
+            hour: '2-digit',
+            minute: '2-digit'
         });
-        
+
         row.innerHTML = `
             <td>${operationDate}</td>
             <td>${timestampDate}<br><small class="text-muted">${timestampTime}</small></td>
             <td>${operation.client_name}</td>
-            <td class="${typeClass}">${typeText}</td>
-            <td class="${typeClass}">${formatCurrency(operation.amount)}</td>
+            <td>${typePill}</td>
+            <td class="${amountClass}">${isCredit ? '+' : '−'} ${formatCurrency(operation.amount)}</td>
             <td>${operation.description || '-'}</td>
             <td>${operation.created_by_name}</td>
             <td>${actionsHtml}</td>
         `;
-        
+
         tbody.appendChild(row);
     });
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3204,6 +3204,12 @@
                             <button type="button" class="tab-button" data-config="stock-permissions">
                                 <i class="fas fa-user-check"></i> Permissions Stock Vivant
                             </button>
+                            <button type="button" class="tab-button" data-config="invoice-template">
+                                <i class="fas fa-file-invoice"></i> Modèle de facture
+                            </button>
+                            <button type="button" class="tab-button" data-config="comptable-docs">
+                                <i class="fas fa-folder-open"></i> Documents comptables
+                            </button>
                         </div>
 
                         <!-- Configuration des Catégories -->
@@ -3475,6 +3481,288 @@
                                     <h4><i class="fas fa-users"></i> Permissions Actuelles</h4>
                                     <div id="permissions-list" class="permissions-list">
                                         <p>Chargement des permissions...</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Modèle de facture -->
+                        <div id="invoice-template-config" class="config-panel">
+                            <div class="config-header">
+                                <h3><i class="fas fa-file-invoice"></i> Modèle de facture</h3>
+                                <p class="section-description">Gérer les profils fournisseurs (Nom / Lieu / Téléphone) et les alias d'orthographe utilisés en en-tête des factures PDF.</p>
+                            </div>
+
+                            <!-- Aperçu rapide du modèle -->
+                            <div class="qw-invoice-preview-card">
+                                <div class="qw-invoice-preview-head">
+                                    <h4><i class="fas fa-eye"></i> Aperçu du modèle</h4>
+                                    <p>Saisis un nom de fournisseur pour voir le rendu de l'en-tête (les alias et profils enregistrés sont appliqués).</p>
+                                </div>
+                                <div class="qw-invoice-preview-row">
+                                    <input type="text" id="invoice-preview-supplier" class="form-control" placeholder="ex. Ali KA ou Fournisseur DEMO" maxlength="120">
+                                    <button type="button" id="invoice-preview-btn" class="btn btn-primary">
+                                        <i class="fas fa-file-pdf"></i> Voir l'aperçu
+                                    </button>
+                                </div>
+                            </div>
+
+                            <!-- Profils fournisseurs -->
+                            <div class="qw-invoice-card">
+                                <div class="qw-invoice-card-head">
+                                    <h4><i class="fas fa-id-card"></i> Profils fournisseurs</h4>
+                                    <p>Quand un profil existe pour un fournisseur, la facture affiche <strong>Nom / Lieu d'activité / Téléphone</strong> au lieu du simple nom.</p>
+                                    <button type="button" id="invoice-add-profile-btn" class="btn btn-secondary">
+                                        <i class="fas fa-plus"></i> Ajouter un profil
+                                    </button>
+                                </div>
+                                <div class="table-container">
+                                    <table class="data-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Nom canonique</th>
+                                                <th>Nom affiché</th>
+                                                <th>Lieu d'activité</th>
+                                                <th>Téléphone</th>
+                                                <th style="width: 90px;">Actions</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="invoice-profiles-tbody">
+                                            <tr><td colspan="5" style="text-align: center; color: var(--qw-text-secondary);">Chargement…</td></tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+
+                            <!-- Alias -->
+                            <div class="qw-invoice-card">
+                                <div class="qw-invoice-card-head">
+                                    <h4><i class="fas fa-link"></i> Alias d'orthographe</h4>
+                                    <p>Toutes les orthographes listées à gauche seront converties en la <strong>forme canonique</strong> à droite (case-insensitive, espaces multiples ignorés).</p>
+                                    <button type="button" id="invoice-add-alias-btn" class="btn btn-secondary">
+                                        <i class="fas fa-plus"></i> Ajouter un alias
+                                    </button>
+                                </div>
+                                <div class="table-container">
+                                    <table class="data-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Alias (orthographe brute)</th>
+                                                <th>Forme canonique</th>
+                                                <th style="width: 90px;">Actions</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="invoice-aliases-tbody">
+                                            <tr><td colspan="3" style="text-align: center; color: var(--qw-text-secondary);">Chargement…</td></tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+
+                            <!-- Actions globales (alias + profils fournisseurs) -->
+                            <div class="qw-invoice-actions">
+                                <button type="button" id="invoice-template-save-btn" class="btn btn-primary">
+                                    <i class="fas fa-save"></i> Enregistrer les modifications
+                                </button>
+                                <button type="button" id="invoice-template-reload-btn" class="btn btn-secondary">
+                                    <i class="fas fa-undo"></i> Annuler / Recharger
+                                </button>
+                                <span id="invoice-template-status" class="qw-invoice-status" aria-live="polite"></span>
+                            </div>
+
+                            <!-- ============================================== -->
+                            <!-- FACTURE CRÉANCE — Template "ancien format MATA" -->
+                            <!-- ============================================== -->
+                            <div class="qw-invoice-card" style="margin-top: 28px;">
+                                <div class="qw-invoice-card-head">
+                                    <h4><i class="fas fa-receipt"></i> Facture Créance (ancien format MATA)</h4>
+                                    <p>Modèle utilisé pour les factures générées depuis <strong>Gestion Créance &gt; Vue Globale &gt; Par client</strong>. Tous les champs sont modifiables — laisse vide pour revenir à la valeur par défaut.</p>
+                                </div>
+
+                                <div class="qw-creance-tpl-grid">
+                                    <div class="form-group">
+                                        <label for="creance-tpl-company">Nom de l'entreprise</label>
+                                        <input type="text" id="creance-tpl-company" class="form-control" maxlength="120" placeholder="MATA">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="creance-tpl-color">Couleur du titre</label>
+                                        <div class="qw-color-input-wrap">
+                                            <input type="color" id="creance-tpl-color-picker" value="#1e3a8a">
+                                            <input type="text" id="creance-tpl-color" class="form-control" maxlength="7" placeholder="#1e3a8a">
+                                        </div>
+                                    </div>
+                                    <div class="form-group qw-span-2">
+                                        <label for="creance-tpl-addr1">Adresse — Ligne 1</label>
+                                        <input type="text" id="creance-tpl-addr1" class="form-control" maxlength="200" placeholder="Virage, Apt Nord 603D, Résidence Aquanique">
+                                    </div>
+                                    <div class="form-group qw-span-2">
+                                        <label for="creance-tpl-addr2">Adresse — Ligne 2 (NINEA / RC)</label>
+                                        <input type="text" id="creance-tpl-addr2" class="form-control" maxlength="200" placeholder="A : 01387695 2Y3 / RC : SN DKR 2024 B 29149">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="creance-tpl-addr3">Adresse — Ligne 3</label>
+                                        <input type="text" id="creance-tpl-addr3" class="form-control" maxlength="200" placeholder="Ouest foire : 78 480 95 95">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="creance-tpl-addr4">Adresse — Ligne 4</label>
+                                        <input type="text" id="creance-tpl-addr4" class="form-control" maxlength="200" placeholder="Grand Mbao / cité Aliou Sow : 77 858 96 96">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="creance-tpl-designation">Désignation produit (cellule du tableau)</label>
+                                        <input type="text" id="creance-tpl-designation" class="form-control" maxlength="120" placeholder="Produits frais">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="creance-tpl-categories">Catégories affichées sous le total</label>
+                                        <input type="text" id="creance-tpl-categories" class="form-control" maxlength="200" placeholder="bœuf, agneau, poulet">
+                                    </div>
+                                </div>
+
+                                <div class="qw-invoice-actions" style="margin-top: 14px;">
+                                    <button type="button" id="creance-tpl-preview-btn" class="btn btn-secondary">
+                                        <i class="fas fa-file-pdf"></i> Aperçu facture créance
+                                    </button>
+                                    <button type="button" id="creance-tpl-save-btn" class="btn btn-primary">
+                                        <i class="fas fa-save"></i> Enregistrer le modèle créance
+                                    </button>
+                                    <button type="button" id="creance-tpl-reload-btn" class="btn btn-secondary">
+                                        <i class="fas fa-undo"></i> Annuler / Recharger
+                                    </button>
+                                    <span id="creance-tpl-status" class="qw-invoice-status" aria-live="polite"></span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- ============================================== -->
+                        <!-- DOCUMENTS COMPTABLES                            -->
+                        <!-- ============================================== -->
+                        <div id="comptable-docs-config" class="config-panel">
+                            <div class="config-header">
+                                <h3><i class="fas fa-folder-open"></i> Documents comptables</h3>
+                                <p class="section-description">Espace protégé pour stocker factures, justificatifs et états comptables. L'accès est verrouillé par un mot de passe partagé (configurable ci-dessous, super-admin uniquement).</p>
+                            </div>
+
+                            <!-- ===== SOUS-SECTION : Configuration mot de passe (super admin only) ===== -->
+                            <details id="comptable-pwd-config-card" class="qw-invoice-card" style="margin-bottom: 16px;">
+                                <summary class="qw-invoice-card-head" style="cursor: pointer; display: block;">
+                                    <h4 style="display: inline-flex; align-items: center; gap: 8px;">
+                                        <i class="fas fa-key"></i> Mot de passe d'accès (super-admin)
+                                    </h4>
+                                    <p style="margin-top: 4px;">
+                                        Définir ou changer le mot de passe partagé. <span id="comptable-pwd-state" class="qw-pill qw-pill-muted" style="margin-left: 6px;">État : —</span>
+                                    </p>
+                                </summary>
+                                <div style="padding-top: 8px;">
+                                    <div class="form-group" id="comptable-pwd-current-wrap" style="display: none;">
+                                        <label for="comptable-pwd-current">Mot de passe actuel</label>
+                                        <input type="password" id="comptable-pwd-current" class="form-control" autocomplete="current-password">
+                                        <small style="color: var(--qw-text-secondary);">Requis sauf si vous êtes admin strict (rôle <code>admin</code>).</small>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="comptable-pwd-new">Nouveau mot de passe</label>
+                                        <input type="password" id="comptable-pwd-new" class="form-control" autocomplete="new-password" minlength="6">
+                                        <small style="color: var(--qw-text-secondary);">Minimum 6 caractères.</small>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="comptable-pwd-confirm">Confirmer le nouveau mot de passe</label>
+                                        <input type="password" id="comptable-pwd-confirm" class="form-control" autocomplete="new-password">
+                                    </div>
+                                    <div class="qw-invoice-actions">
+                                        <button type="button" id="comptable-pwd-save-btn" class="btn btn-primary">
+                                            <i class="fas fa-save"></i> Enregistrer le mot de passe
+                                        </button>
+                                        <span id="comptable-pwd-status" class="qw-invoice-status" aria-live="polite"></span>
+                                    </div>
+                                </div>
+                            </details>
+
+                            <!-- ===== LOCK SCREEN (visible quand pas déverrouillé) ===== -->
+                            <div id="comptable-lock-screen" class="qw-comptable-lock-card">
+                                <div class="qw-comptable-lock-icon">
+                                    <i class="fas fa-lock"></i>
+                                </div>
+                                <h3>Accès protégé</h3>
+                                <p id="comptable-lock-msg">Cette section est verrouillée par un mot de passe partagé.</p>
+                                <div class="qw-comptable-lock-form">
+                                    <label for="comptable-unlock-pwd" class="visually-hidden">Mot de passe</label>
+                                    <input type="password" id="comptable-unlock-pwd" class="form-control" placeholder="Mot de passe d'accès" autocomplete="off">
+                                    <button type="button" id="comptable-unlock-btn" class="btn btn-primary">
+                                        <i class="fas fa-unlock"></i> Déverrouiller
+                                    </button>
+                                </div>
+                                <p id="comptable-unlock-error" class="qw-invoice-status qw-invoice-status-error" style="min-height: 18px;"></p>
+                            </div>
+
+                            <!-- ===== MAIN VIEW (visible une fois déverrouillé) ===== -->
+                            <div id="comptable-main" style="display: none;">
+                                <div class="qw-comptable-status-bar">
+                                    <span class="qw-pill qw-pill-success">
+                                        <i class="fas fa-unlock"></i> Session active — <span id="comptable-ttl-remaining">30:00</span>
+                                    </span>
+                                    <button type="button" id="comptable-lock-btn" class="btn btn-secondary btn-sm">
+                                        <i class="fas fa-lock"></i> Verrouiller maintenant
+                                    </button>
+                                </div>
+
+                                <!-- Upload card -->
+                                <div class="qw-invoice-card" style="margin-top: 14px;">
+                                    <div class="qw-invoice-card-head">
+                                        <h4><i class="fas fa-upload"></i> Ajouter un document</h4>
+                                        <p>Formats acceptés : PDF, Word (.doc / .docx), Excel (.xls / .xlsx), images (JPG / PNG). Max 50 Mo par fichier.</p>
+                                    </div>
+                                    <form id="comptable-upload-form" enctype="multipart/form-data">
+                                        <div class="qw-comptable-upload-grid">
+                                            <div class="form-group qw-span-2">
+                                                <label for="comptable-upload-libelle">Libellé</label>
+                                                <input type="text" id="comptable-upload-libelle" class="form-control" maxlength="255" required placeholder="ex. Bilan exercice 2026, Quittance EDF mars, etc.">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="comptable-upload-year">Année</label>
+                                                <input type="number" id="comptable-upload-year" class="form-control" required min="2000" max="2100">
+                                            </div>
+                                            <div class="form-group qw-span-3">
+                                                <label for="comptable-upload-file">Fichier</label>
+                                                <input type="file" id="comptable-upload-file" class="form-control" required accept=".pdf,.doc,.docx,.xls,.xlsx,.jpg,.jpeg,.png,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,image/jpeg,image/png">
+                                            </div>
+                                        </div>
+                                        <div class="qw-invoice-actions" style="margin-top: 12px;">
+                                            <button type="submit" id="comptable-upload-btn" class="btn btn-primary">
+                                                <i class="fas fa-cloud-upload-alt"></i> Téléverser
+                                            </button>
+                                            <span id="comptable-upload-status" class="qw-invoice-status" aria-live="polite"></span>
+                                        </div>
+                                    </form>
+                                </div>
+
+                                <!-- Filter + list -->
+                                <div class="qw-invoice-card" style="margin-top: 14px;">
+                                    <div class="qw-invoice-card-head">
+                                        <h4><i class="fas fa-list"></i> Documents par année</h4>
+                                        <p>Sélectionne une année pour voir les documents associés.</p>
+                                    </div>
+                                    <div class="qw-comptable-filter-row">
+                                        <label for="comptable-filter-year">Année</label>
+                                        <select id="comptable-filter-year" class="form-control"></select>
+                                        <button type="button" id="comptable-refresh-btn" class="btn btn-secondary btn-sm">
+                                            <i class="fas fa-sync"></i> Rafraîchir
+                                        </button>
+                                    </div>
+                                    <div class="table-container" style="margin-top: 10px;">
+                                        <table class="data-table">
+                                            <thead>
+                                                <tr>
+                                                    <th>Libellé</th>
+                                                    <th>Année</th>
+                                                    <th>Fichier</th>
+                                                    <th>Taille</th>
+                                                    <th>Date d'ajout</th>
+                                                    <th>Ajouté par</th>
+                                                    <th style="width: 160px;">Actions</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="comptable-docs-tbody">
+                                                <tr><td colspan="7" style="text-align: center; color: var(--qw-text-secondary);">Chargement…</td></tr>
+                                            </tbody>
+                                        </table>
                                     </div>
                                 </div>
                             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -15623,3 +15623,50 @@ span.previsible-no,
     border-top-color: var(--qw-border);
 }
 
+/* =========================================================
+   CREANCE — Historique des opérations : différencier
+   visuellement Avance (vert) vs Remboursement (rouge)
+   ========================================================= */
+
+/* Le pill type prend le pas sur la couleur de cellule par défaut */
+.data-table td .qw-op-type-pill {
+    color: inherit !important;
+    font-weight: 500 !important;
+}
+
+/* Cellule montant : couleur explicite, signé visible */
+.data-table td.qw-op-amount-credit {
+    color: #15803d !important;
+    font-weight: 600 !important;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+.data-table td.qw-op-amount-debit {
+    color: #b91c1c !important;
+    font-weight: 600 !important;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+/* Liseré gauche subtil sur la ligne pour renforcer la distinction */
+.data-table tbody tr.qw-op-row-credit > td:first-child {
+    box-shadow: inset 3px 0 0 0 rgba(34, 197, 94, 0.55);
+}
+.data-table tbody tr.qw-op-row-debit > td:first-child {
+    box-shadow: inset 3px 0 0 0 rgba(220, 38, 38, 0.55);
+}
+
+/* Dark mode : montants plus lisibles sur fond sombre */
+[data-theme="dark"] .data-table td.qw-op-amount-credit {
+    color: #4ade80 !important;
+}
+[data-theme="dark"] .data-table td.qw-op-amount-debit {
+    color: #f87171 !important;
+}
+[data-theme="dark"] .data-table tbody tr.qw-op-row-credit > td:first-child {
+    box-shadow: inset 3px 0 0 0 rgba(74, 222, 128, 0.55);
+}
+[data-theme="dark"] .data-table tbody tr.qw-op-row-debit > td:first-child {
+    box-shadow: inset 3px 0 0 0 rgba(248, 113, 113, 0.55);
+}
+

--- a/public/styles.css
+++ b/public/styles.css
@@ -15670,3 +15670,339 @@ span.previsible-no,
     box-shadow: inset 3px 0 0 0 rgba(248, 113, 113, 0.55);
 }
 
+/* =========================================================
+   ADMIN — Modèle de facture
+   ========================================================= */
+
+.qw-invoice-preview-card,
+.qw-invoice-card {
+    background: var(--qw-surface);
+    border: 1px solid var(--qw-border);
+    border-radius: var(--qw-radius-lg);
+    padding: 18px 20px;
+    margin-bottom: 16px;
+    box-shadow: var(--qw-shadow-sm);
+}
+.qw-invoice-preview-card {
+    border-left: 4px solid var(--qw-primary);
+}
+.qw-invoice-preview-head h4,
+.qw-invoice-card-head h4 {
+    margin: 0 0 4px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--qw-text);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.qw-invoice-preview-head h4 i,
+.qw-invoice-card-head h4 i {
+    color: var(--qw-primary);
+}
+.qw-invoice-preview-head p,
+.qw-invoice-card-head p {
+    margin: 0 0 12px;
+    color: var(--qw-text-secondary);
+    font-size: 13px;
+}
+.qw-invoice-preview-row {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+.qw-invoice-preview-row input {
+    flex: 1;
+    min-width: 240px;
+}
+
+.qw-invoice-card-head {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    margin-bottom: 12px;
+    position: relative;
+}
+.qw-invoice-card-head > button {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
+.qw-invoice-actions {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: 8px;
+}
+.qw-invoice-status {
+    margin-left: auto;
+    font-size: 13px;
+    color: var(--qw-text-secondary);
+}
+.qw-invoice-status-ok { color: #15803d; }
+.qw-invoice-status-error { color: #b91c1c; }
+.qw-invoice-status-pending { color: #b45309; }
+
+/* Inputs compacts dans les tables admin */
+#invoice-template-config .data-table input.form-control {
+    padding: 6px 10px !important;
+    font-size: 13px !important;
+    height: auto !important;
+    width: 100%;
+}
+#invoice-template-config .data-table .btn-sm {
+    padding: 6px 10px;
+    font-size: 12px;
+}
+
+[data-theme="dark"] .qw-invoice-status-ok { color: #4ade80; }
+[data-theme="dark"] .qw-invoice-status-error { color: #f87171; }
+[data-theme="dark"] .qw-invoice-status-pending { color: #fbbf24; }
+
+/* =========================================================
+   FACTURE CRÉANCE — Config form + Vue Par Client actions
+   ========================================================= */
+
+/* Grille du formulaire du modèle créance (2 colonnes desktop, 1 mobile) */
+.qw-creance-tpl-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px 16px;
+    margin-bottom: 12px;
+}
+.qw-creance-tpl-grid .qw-span-2 {
+    grid-column: 1 / -1;
+}
+.qw-creance-tpl-grid .form-group {
+    margin-bottom: 0;
+}
+.qw-creance-tpl-grid .form-group label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--qw-text-secondary);
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+.qw-creance-tpl-grid .form-group input.form-control {
+    padding: 8px 12px !important;
+    font-size: 13px !important;
+    height: auto !important;
+}
+
+/* Couleur : color picker + champ texte côte à côte */
+.qw-color-input-wrap {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+}
+.qw-color-input-wrap input[type="color"] {
+    width: 44px;
+    min-width: 44px;
+    height: 36px;
+    padding: 2px;
+    border: 1px solid var(--qw-border);
+    border-radius: 6px;
+    cursor: pointer;
+    background: var(--qw-surface);
+}
+.qw-color-input-wrap input[type="text"] {
+    flex: 1;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace !important;
+    font-size: 12.5px !important;
+    text-transform: uppercase;
+}
+
+@media (max-width: 768px) {
+    .qw-creance-tpl-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Bouton "Générer toutes les factures" + hint dans Vue Par Client */
+.qw-client-actions-bar {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+    padding: 12px 16px;
+    background: var(--qw-primary-soft, #eff6ff);
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    border-left: 4px solid var(--qw-primary);
+    border-radius: var(--qw-radius-lg);
+    margin-bottom: 12px;
+}
+.qw-client-actions-bar .btn {
+    flex: 0 0 auto;
+}
+.qw-client-actions-hint {
+    color: var(--qw-text-secondary);
+    font-size: 12.5px;
+    line-height: 1.4;
+    flex: 1;
+    min-width: 200px;
+}
+[data-theme="dark"] .qw-client-actions-bar {
+    background: rgba(37, 99, 235, 0.12);
+    border-color: rgba(37, 99, 235, 0.3);
+}
+
+/* Bouton "Facture" par ligne (compact, ghost) */
+.qw-btn-creance-invoice.btn-sm,
+.btn.btn-sm.qw-btn-creance-invoice {
+    padding: 4px 10px !important;
+    font-size: 11.5px !important;
+    line-height: 1.4 !important;
+    white-space: nowrap;
+}
+.qw-btn-creance-invoice i {
+    font-size: 10px;
+    margin-right: 3px;
+}
+
+/* =========================================================
+   DOCUMENTS COMPTABLES — lock screen + main view
+   ========================================================= */
+
+/* Lock screen : carte centrale avec icône cadenas */
+.qw-comptable-lock-card {
+    background: var(--qw-surface);
+    border: 1px solid var(--qw-border);
+    border-radius: var(--qw-radius-lg);
+    box-shadow: var(--qw-shadow-sm);
+    padding: 36px 28px 28px;
+    text-align: center;
+    max-width: 460px;
+    margin: 24px auto;
+}
+.qw-comptable-lock-icon {
+    width: 72px;
+    height: 72px;
+    margin: 0 auto 16px;
+    border-radius: 50%;
+    background: var(--qw-primary-soft, #eff6ff);
+    color: var(--qw-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 28px;
+}
+.qw-comptable-lock-card h3 {
+    margin: 0 0 6px;
+    color: var(--qw-text);
+    font-size: 18px;
+    font-weight: 600;
+}
+.qw-comptable-lock-card > p {
+    color: var(--qw-text-secondary);
+    font-size: 13px;
+    margin: 0 auto 16px;
+    max-width: 380px;
+}
+.qw-comptable-lock-form {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 8px;
+    max-width: 380px;
+    margin-left: auto;
+    margin-right: auto;
+}
+.qw-comptable-lock-form input {
+    flex: 1;
+}
+.qw-comptable-lock-form .btn {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+[data-theme="dark"] .qw-comptable-lock-icon {
+    background: rgba(37, 99, 235, 0.15);
+}
+
+/* Barre de statut quand session déverrouillée */
+.qw-comptable-status-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 10px 14px;
+    background: rgba(34, 197, 94, 0.08);
+    border: 1px solid rgba(34, 197, 94, 0.25);
+    border-left: 4px solid #15803d;
+    border-radius: var(--qw-radius-lg);
+}
+.qw-comptable-status-bar .qw-pill {
+    font-size: 13px;
+    padding: 5px 12px;
+}
+.qw-comptable-status-bar .qw-pill i {
+    font-size: 11px;
+}
+[data-theme="dark"] .qw-comptable-status-bar {
+    background: rgba(34, 197, 94, 0.12);
+}
+
+/* Grid pour le formulaire d'upload (3 colonnes : libelle x2 + année puis fichier full width) */
+.qw-comptable-upload-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 12px 16px;
+}
+.qw-comptable-upload-grid .qw-span-2 {
+    grid-column: 1 / -1;
+}
+.qw-comptable-upload-grid .qw-span-3 {
+    grid-column: 1 / -1;
+}
+.qw-comptable-upload-grid .form-group {
+    margin-bottom: 0;
+}
+.qw-comptable-upload-grid .form-group label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--qw-text-secondary);
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+.qw-comptable-upload-grid .form-group input.form-control {
+    padding: 8px 12px !important;
+    font-size: 13px !important;
+    height: auto !important;
+}
+
+@media (max-width: 640px) {
+    .qw-comptable-upload-grid {
+        grid-template-columns: 1fr;
+    }
+    .qw-comptable-upload-grid .qw-span-2,
+    .qw-comptable-upload-grid .qw-span-3 {
+        grid-column: 1 / -1;
+    }
+}
+
+/* Filter row : Année + bouton refresh */
+.qw-comptable-filter-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+.qw-comptable-filter-row label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--qw-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+.qw-comptable-filter-row select.form-control {
+    max-width: 160px;
+    padding: 6px 10px !important;
+    height: auto !important;
+}
+

--- a/server.js
+++ b/server.js
@@ -21,6 +21,317 @@ function formatCurrency(amount) {
     return parseInt(amount).toLocaleString('fr-FR') + ' FCFA';
 }
 
+// Valeurs par défaut (utilisées si la table app_settings n'a pas encore
+// été peuplée pour la facture). Ces defaults sont mergés avec les
+// valeurs DB pour que la suppression d'une entrée DB ne laisse pas
+// l'app sans les alias historiques.
+const DEFAULT_SUPPLIER_ALIASES = {
+    'ali ka': 'Ali KA',
+    'aly ka': 'Ali KA',
+    'ali  ka': 'Ali KA'
+};
+const DEFAULT_SUPPLIER_PROFILES = {
+    'Ali KA': {
+        displayName: 'Aly Ka, marchand de bétail',
+        location: 'Foirail de Sicap Mbao',
+        phone: '778625595'
+    }
+};
+
+/**
+ * Charge la config "template facture" depuis app_settings, mémorisée 30 s.
+ * Sources : DB (clés invoice_supplier_aliases / invoice_supplier_profiles)
+ * + defaults hardcodés. DB écrase les defaults clé par clé.
+ * @returns {Promise<{aliases: Object<string,string>, profiles: Object<string,Object>}>}
+ */
+async function getInvoiceTemplateConfig() {
+    const now = Date.now();
+    if (invoiceTemplateCache && (now - invoiceTemplateCacheTime) < CONFIG_CACHE_TTL_MS) {
+        return invoiceTemplateCache;
+    }
+    let dbAliases = null;
+    let dbProfiles = null;
+    try {
+        const r = await pool.query(
+            "SELECT key, value FROM app_settings WHERE key IN ('invoice_supplier_aliases', 'invoice_supplier_profiles')"
+        );
+        for (const row of r.rows) {
+            if (row.key === 'invoice_supplier_aliases' && row.value && typeof row.value === 'object') {
+                dbAliases = row.value;
+            } else if (row.key === 'invoice_supplier_profiles' && row.value && typeof row.value === 'object') {
+                dbProfiles = row.value;
+            }
+        }
+    } catch (error) {
+        if (error.code !== PG_UNDEFINED_TABLE) {
+            console.error('Erreur lecture app_settings invoice template (fallback defaults):', error.message);
+        }
+    }
+    const aliases = { ...DEFAULT_SUPPLIER_ALIASES, ...(dbAliases || {}) };
+    const profiles = { ...DEFAULT_SUPPLIER_PROFILES, ...(dbProfiles || {}) };
+    invoiceTemplateCache = { aliases, profiles };
+    invoiceTemplateCacheTime = now;
+    return invoiceTemplateCache;
+}
+
+/**
+ * Normalise un nom de fournisseur :
+ * - trim, normalisation des espaces
+ * - lookup dans le map d'alias fourni (case-insensitive)
+ * @param {string|null|undefined} name
+ * @param {Object<string,string>} aliasMap  Doit être déjà chargé (cf. getInvoiceTemplateConfig)
+ */
+function normalizeSupplierName(name, aliasMap) {
+    if (!name || typeof name !== 'string') return '';
+    const trimmed = name.trim();
+    if (!trimmed) return '';
+    const key = trimmed.toLowerCase().replace(/\s+/g, ' ');
+    return (aliasMap && aliasMap[key]) || trimmed;
+}
+
+/**
+ * Formate un numéro de téléphone sénégalais (9 chiffres) en groupes
+ * lisibles : 778625595 -> "77 862 55 95". Pour les autres formats,
+ * on renvoie la valeur d'origine telle quelle.
+ */
+function formatSupplierPhone(raw) {
+    if (!raw) return '';
+    const digits = String(raw).replace(/\D/g, '');
+    if (digits.length === 9) {
+        return `${digits.slice(0, 2)} ${digits.slice(2, 5)} ${digits.slice(5, 7)} ${digits.slice(7, 9)}`;
+    }
+    return String(raw);
+}
+
+/**
+ * Rend l'en-tête fournisseur en haut à gauche d'une facture PDF.
+ * Si un profil complet existe pour la forme canonique, on affiche
+ * Nom / Lieu d'activité / Téléphone. Sinon, juste le nom en gras.
+ * @param {PDFDocument} doc
+ * @param {string|null|undefined} rawName
+ * @param {{aliases: Object, profiles: Object}} config  Charger via getInvoiceTemplateConfig()
+ */
+function renderSupplierHeader(doc, rawName, config) {
+    const aliases = (config && config.aliases) || DEFAULT_SUPPLIER_ALIASES;
+    const profiles = (config && config.profiles) || DEFAULT_SUPPLIER_PROFILES;
+    const canonical = normalizeSupplierName(rawName, aliases);
+    const profile = profiles[canonical];
+
+    if (profile) {
+        // Layout type "facture pro" : un bandeau d'accentuation vertical
+        // bleu à gauche, le nom du fournisseur en hero, puis l'adresse
+        // et le téléphone dessous en typographie sobre. Pas de préfixes
+        // verbeux ("Nom :", "Lieu d'activité :"...) qui alourdissent.
+        const barX = 50;             // Position du bandeau d'accent
+        const contentX = 64;         // Texte décalé pour laisser respirer après le bandeau
+        const blockTop = 50;
+        let y = blockTop;
+
+        // Pré-calcul : on dessine le texte AVANT le bandeau pour
+        // connaître la hauteur finale et tracer un bandeau de la
+        // bonne longueur (PDFKit ne sait pas mesurer après coup).
+
+        // Nom hero (sombre, semi-gras, taille équilibrée — pas trop grosse
+        // comme dans les vraies factures pro)
+        doc.fontSize(15).font('Helvetica-Bold').fillColor('#0f172a')
+            .text(profile.displayName || canonical || '', contentX, y, { width: 360 });
+        y = doc.y + 6; // récupère la position courante après wrap éventuel
+
+        // Adresse / lieu d'activité (gris moyen, taille discrète)
+        if (profile.location) {
+            doc.fontSize(9.5).font('Helvetica').fillColor('#475569')
+                .text(profile.location, contentX, y, { width: 360 });
+            y = doc.y + 2;
+        }
+
+        // Téléphone avec préfixe "Tél." et indicatif international +221
+        // (formatage en groupes lisibles 77 862 55 95)
+        if (profile.phone) {
+            const formatted = formatSupplierPhone(profile.phone);
+            doc.fontSize(9.5).font('Helvetica').fillColor('#475569')
+                .text(`Tél. +221 ${formatted}`, contentX, y);
+            y = doc.y + 2;
+        }
+
+        // Bandeau d'accentuation vertical bleu (cadre sur la gauche),
+        // hauteur calée sur la hauteur réelle du bloc texte.
+        const blockBottom = y;
+        const barHeight = Math.max(36, blockBottom - blockTop);
+        doc.rect(barX, blockTop, 3, barHeight).fill('#1e3a8a');
+
+        // Reset des couleurs / police pour ne pas polluer le reste
+        doc.fillColor('black').strokeColor('black').lineWidth(1);
+    } else {
+        // Pas de profil : juste le nom en gros gras
+        doc.fontSize(20).font('Helvetica-Bold').fillColor('black')
+            .text(canonical || '', 50, 55);
+    }
+}
+
+// =====================================================
+// TEMPLATE FACTURE CRÉANCE (ancien format MATA)
+// =====================================================
+// Utilisé par les factures générées depuis Gestion Créance > Vue Globale
+// > Par client. Tous les champs sont éditables depuis Config > Modèle
+// de facture > Facture Créance.
+
+const DEFAULT_CREANCE_INVOICE_TEMPLATE = {
+    company_name: 'MATA',
+    address_line_1: 'Virage, Apt Nord 603D, Résidence Aquanique',
+    address_line_2: 'A : 01387695 2Y3 / RC : SN DKR 2024 B 29149',
+    address_line_3: 'Ouest foire : 78 480 95 95',
+    address_line_4: '',
+    designation: 'Produits frais',
+    categories: 'bœuf, agneau, poulet',
+    title_color: '#1e3a8a'
+};
+
+/**
+ * Charge le template de facture créance depuis app_settings (clé
+ * invoice_creance_template), mémorisé 30 s. Defaults mergés.
+ */
+async function getCreanceInvoiceTemplate() {
+    const now = Date.now();
+    if (creanceInvoiceTemplateCache && (now - creanceInvoiceTemplateCacheTime) < CONFIG_CACHE_TTL_MS) {
+        return creanceInvoiceTemplateCache;
+    }
+    let db = null;
+    try {
+        const r = await pool.query(
+            "SELECT value FROM app_settings WHERE key = 'invoice_creance_template' LIMIT 1"
+        );
+        if (r.rows.length > 0 && r.rows[0].value && typeof r.rows[0].value === 'object') {
+            db = r.rows[0].value;
+        }
+    } catch (error) {
+        if (error.code !== PG_UNDEFINED_TABLE) {
+            console.error('Erreur lecture invoice_creance_template (fallback defaults):', error.message);
+        }
+    }
+    const merged = { ...DEFAULT_CREANCE_INVOICE_TEMPLATE, ...(db || {}) };
+    creanceInvoiceTemplateCache = merged;
+    creanceInvoiceTemplateCacheTime = now;
+    return merged;
+}
+
+/**
+ * Génère une page de facture créance MATA pour un client.
+ * @param {PDFDocument} doc
+ * @param {{name: string, portfolio: string, solde: number}} clientData
+ * @param {Object} tpl  Template chargé via getCreanceInvoiceTemplate()
+ * @param {string|number} invoiceNumber  N° unique de la facture
+ */
+function renderCreanceInvoice(doc, clientData, tpl, invoiceNumber) {
+    const T = tpl || DEFAULT_CREANCE_INVOICE_TEMPLATE;
+    const color = T.title_color || '#1e3a8a';
+    const formatNumber = n => (parseFloat(n) || 0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+
+    // === EN-TÊTE MATA (ancien format) ===
+    doc.fontSize(24).font('Helvetica-Bold').fillColor(color)
+        .text(T.company_name || 'MATA', 50, 50);
+
+    doc.fontSize(9).font('Helvetica').fillColor('black');
+    if (T.address_line_1) doc.text(T.address_line_1, 50, 80);
+    if (T.address_line_2) doc.text(T.address_line_2, 50, 95);
+    if (T.address_line_3) doc.text(T.address_line_3, 50, 110);
+    if (T.address_line_4) doc.text(T.address_line_4, 50, 125);
+
+    // FACTURE title (centré façon historique)
+    doc.fontSize(16).font('Helvetica-Bold').fillColor(color).text('FACTURE', 275, 55);
+
+    // Date + N°
+    doc.fontSize(10).font('Helvetica').fillColor('black');
+    const currentDate = new Date().toLocaleDateString('fr-FR');
+    doc.text(`Date : ${currentDate}`, 450, 50);
+    doc.fontSize(12).font('Helvetica-Bold').fillColor('#dc2626');
+    doc.text(`N° : ${invoiceNumber}`, 450, 70);
+
+    // Ligne de séparation
+    doc.strokeColor(color).lineWidth(1);
+    doc.moveTo(50, 160).lineTo(545, 160).stroke();
+
+    // Titre de section
+    let yPos = 180;
+    doc.fontSize(14).font('Helvetica-Bold').fillColor('black');
+    doc.text('Dépenses', 50, yPos);
+    yPos += 30;
+
+    // En-tête du tableau
+    const tableStartY = yPos;
+    const colPositions = [50, 110, 330, 430];
+    doc.rect(50, tableStartY, 495, 25).fill(color);
+    doc.fontSize(11).font('Helvetica-Bold').fillColor('white');
+    doc.text('QUANTITÉ', colPositions[0] + 5, tableStartY + 8);
+    doc.text('DÉSIGNATION', colPositions[1] + 5, tableStartY + 8);
+    doc.text('P. UNITAIRE', colPositions[2] + 5, tableStartY + 8);
+    doc.text('PRIX TOTAL', colPositions[3] + 5, tableStartY + 8);
+    yPos = tableStartY + 25;
+
+    // Unique ligne : 1.00 Produits frais [solde] [solde]
+    const solde = parseFloat(clientData && clientData.solde || 0);
+    const formattedSolde = formatNumber(solde);
+    doc.rect(50, yPos, 495, 30).fill('#f8f9fa').stroke('#dee2e6');
+    doc.fontSize(10).font('Helvetica').fillColor('black');
+    doc.text('1.00', colPositions[0] + 5, yPos + 10);
+    doc.text(T.designation || 'Produits frais', colPositions[1] + 5, yPos + 10, { width: 200, height: 20 });
+    doc.text(formattedSolde, colPositions[2] + 5, yPos + 10);
+    doc.text(formattedSolde, colPositions[3] + 5, yPos + 10);
+    yPos += 30;
+
+    // Pas de lignes vides (sur demande)
+
+    // MONTANT TOTAL
+    doc.rect(50, yPos, 495, 3).fill(color);
+    yPos += 10;
+    doc.rect(50, yPos, 360, 30).fill(color);
+    doc.fontSize(14).font('Helvetica-Bold').fillColor('white');
+    doc.text('MONTANT TOTAL', 60, yPos + 10);
+    doc.rect(410, yPos, 135, 30).stroke(color).lineWidth(2);
+    doc.fontSize(16).font('Helvetica-Bold').fillColor(color);
+    doc.text(`${formattedSolde} F`, 420, yPos + 8);
+    yPos += 60;
+
+    // Bloc métadonnées client + catégories
+    doc.fontSize(10).font('Helvetica').fillColor('black');
+    const clientName = (clientData && clientData.name) || '';
+    doc.text(`Client : ${clientName}`, 50, yPos);
+    yPos += 15;
+    if (T.categories) {
+        doc.text(`Catégories de produits : ${T.categories}`, 50, yPos);
+    }
+
+    // Cachet MATA — ancré en bas à droite (marges fixes par rapport au bord
+    // de la page pour que ce soit prévisible quelle que soit la mise en page
+    // au-dessus).
+    const cachetW = 130;
+    const cachetH = 130;
+    const cachetX = doc.page.width - cachetW - 50;   // 50pt depuis le bord droit
+    const cachetY = doc.page.height - cachetH - 50;  // 50pt depuis le bas
+    const cachetPath = path.join(__dirname, 'public', 'images', 'CachetMata.jpg');
+
+    let cachetRendered = false;
+    if (fs.existsSync(cachetPath)) {
+        try {
+            doc.image(cachetPath, cachetX, cachetY, { width: cachetW, height: cachetH });
+            cachetRendered = true;
+        } catch (error) {
+            console.warn('⚠️ Cachet MATA introuvable / illisible, fallback texte :', error.message);
+        }
+    }
+    if (!cachetRendered) {
+        // Fallback : rectangle avec texte centré "CACHET MATA"
+        doc.rect(cachetX, cachetY, cachetW, cachetH).stroke(color).lineWidth(2);
+        doc.fontSize(12).font('Helvetica-Bold').fillColor(color);
+        doc.text('CACHET\nMATA', cachetX, cachetY + cachetH / 2 - 14, {
+            width: cachetW,
+            align: 'center'
+        });
+    }
+
+    // Reset
+    doc.fillColor('black').strokeColor('black').lineWidth(1);
+}
+
 // Fonction utilitaire pour nettoyer l'encodage des caractères français
 function cleanEncoding(obj) {
     if (typeof obj === 'string') {
@@ -79,6 +390,20 @@ let virementClientsContextCacheTime = 0;
 function invalidateVirementClientsCache() {
     virementClientsContextCache = null;
     virementClientsContextCacheTime = 0;
+}
+
+let invoiceTemplateCache = null;
+let invoiceTemplateCacheTime = 0;
+function invalidateInvoiceTemplateCache() {
+    invoiceTemplateCache = null;
+    invoiceTemplateCacheTime = 0;
+}
+
+let creanceInvoiceTemplateCache = null;
+let creanceInvoiceTemplateCacheTime = 0;
+function invalidateCreanceInvoiceTemplateCache() {
+    creanceInvoiceTemplateCache = null;
+    creanceInvoiceTemplateCacheTime = 0;
 }
 
 // Fonction utilitaire pour lire la configuration financière (async, mémorisée 30 s).
@@ -1381,13 +1706,132 @@ const fileFilter = (req, file, cb) => {
     }
 };
 
-const upload = multer({ 
+const upload = multer({
     storage: storage,
     fileFilter: fileFilter,
     limits: {
         fileSize: 5 * 1024 * 1024 // 5MB max
     }
 });
+
+// =====================================================
+// DOCUMENTS COMPTABLES — config & multer
+// =====================================================
+// Upload de documents comptables (factures, justificatifs, états...) accessibles
+// uniquement après déverrouillage par mot de passe partagé. Fichiers stockés
+// sur disque dans uploads/comptable/{year}/{id}-{slug}.ext.
+const COMPTABLE_UPLOAD_BASE_DIR = path.join(__dirname, 'uploads', 'comptable');
+const COMPTABLE_MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+const COMPTABLE_UNLOCK_TTL_MS = 30 * 60 * 1000;   // 30 min d'inactivité
+const COMPTABLE_PASSWORD_SETTING_KEY = 'comptable_password_hash';
+const COMPTABLE_ALLOWED_MIMES = new Set([
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'image/jpeg',
+    'image/png',
+    'image/jpg'
+]);
+const COMPTABLE_ALLOWED_EXTS = new Set([
+    '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.jpg', '.jpeg', '.png'
+]);
+
+// Assurer l'existence du répertoire racine au démarrage
+try {
+    if (!fs.existsSync(COMPTABLE_UPLOAD_BASE_DIR)) {
+        fs.mkdirSync(COMPTABLE_UPLOAD_BASE_DIR, { recursive: true });
+    }
+} catch (err) {
+    console.warn('⚠️ Impossible de créer le répertoire comptable :', err.message);
+}
+
+const comptableStorage = multer.diskStorage({
+    destination: (req, file, cb) => {
+        const year = parseInt(req.body.year, 10) || new Date().getFullYear();
+        if (year < 2000 || year > 2100) {
+            return cb(new Error('Année invalide'), null);
+        }
+        const dir = path.join(COMPTABLE_UPLOAD_BASE_DIR, String(year));
+        try {
+            if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+            cb(null, dir);
+        } catch (err) {
+            cb(err, null);
+        }
+    },
+    filename: (req, file, cb) => {
+        // Nom : {timestamp}-{slug}.ext (l'id DB est ajouté dans le path après l'insert)
+        const ext = path.extname(file.originalname || '').toLowerCase();
+        const base = (file.originalname || 'document')
+            .replace(/\.[^.]+$/, '')
+            .replace(/[^a-zA-Z0-9_-]+/g, '_')
+            .slice(0, 60) || 'document';
+        cb(null, `${Date.now()}_${base}${ext}`);
+    }
+});
+const comptableFileFilter = (req, file, cb) => {
+    const ext = path.extname(file.originalname || '').toLowerCase();
+    const mime = (file.mimetype || '').toLowerCase();
+    if (!COMPTABLE_ALLOWED_EXTS.has(ext) || !COMPTABLE_ALLOWED_MIMES.has(mime)) {
+        return cb(new Error('Format de fichier non autorisé. Acceptés : PDF, Word, Excel, JPG, PNG.'), false);
+    }
+    cb(null, true);
+};
+const comptableUpload = multer({
+    storage: comptableStorage,
+    fileFilter: comptableFileFilter,
+    limits: { fileSize: COMPTABLE_MAX_FILE_SIZE }
+});
+
+/**
+ * Lit le hash bcrypt du mot de passe partagé depuis app_settings.
+ * Retourne null si non configuré.
+ */
+async function getComptablePasswordHash() {
+    try {
+        const r = await pool.query(
+            'SELECT value FROM app_settings WHERE key = $1 LIMIT 1',
+            [COMPTABLE_PASSWORD_SETTING_KEY]
+        );
+        if (r.rows.length === 0) return null;
+        const v = r.rows[0].value;
+        // app_settings.value est JSONB ; on stocke { hash: '$2b$...' }
+        if (v && typeof v === 'object' && typeof v.hash === 'string') return v.hash;
+        return null;
+    } catch (error) {
+        if (error.code !== PG_UNDEFINED_TABLE) {
+            console.error('Erreur lecture comptable password hash:', error.message);
+        }
+        return null;
+    }
+}
+
+/**
+ * Vérifie que la session a déverrouillé l'accès comptable récemment
+ * (dans la fenêtre TTL).
+ */
+function isComptableUnlocked(req) {
+    if (!req.session || !req.session.comptableUnlockedAt) return false;
+    const elapsed = Date.now() - req.session.comptableUnlockedAt;
+    return elapsed >= 0 && elapsed < COMPTABLE_UNLOCK_TTL_MS;
+}
+
+/**
+ * Middleware : exige authentification ET déverrouillage comptable.
+ */
+function requireComptableUnlock(req, res, next) {
+    if (!req.session || !req.session.user) {
+        return res.status(401).json({ error: 'Non authentifié' });
+    }
+    if (!isComptableUnlocked(req)) {
+        return res.status(423).json({ error: 'Section verrouillée — déverrouillez d\'abord', code: 'COMPTABLE_LOCKED' });
+    }
+    // Rafraîchir le TTL à chaque action authentifiée (sliding window)
+    req.session.comptableUnlockedAt = Date.now();
+    next();
+}
 
 // Middleware
 app.use(cors());
@@ -1566,6 +2010,17 @@ function requireSuperAdmin(req, res, next) {
     }
     next();
 }
+
+// Middleware pour vérifier les permissions admin strictes (admin seulement).
+// Déplacé ici (était plus bas dans le fichier) parce que certaines routes
+// l'utilisent avant la position historique de cette déclaration, ce qui
+// déclenchait un ReferenceError TDZ avec const.
+const requireStrictAdminAuth = (req, res, next) => {
+    if (!req.session?.user || req.session.user.role !== 'admin') {
+        return res.status(403).json({ error: 'Accès refusé - Seul l\'admin peut effectuer cette action' });
+    }
+    next();
+};
 
 // Routes d'authentification
 app.post('/api/login', async (req, res) => {
@@ -5036,24 +5491,24 @@ app.post('/api/expenses/generate-invoices-pdf', requireAuth, async (req, res) =>
                 }
             }
             
-            // PARTIE 2: Ajouter les templates MATA pour les dépenses sans justificatifs
-            console.log(`⏱️ PDF GENERATION: Traitement de ${expensesWithoutJustification.length} templates MATA...`);
-            
+            // PARTIE 2: Ajouter les templates de facture pour les dépenses sans justificatifs
+            console.log(`⏱️ PDF GENERATION: Traitement de ${expensesWithoutJustification.length} templates...`);
+            // Charger la config du modèle de facture (alias + profils fournisseurs)
+            // une seule fois pour tout le batch.
+            const invoiceTemplateConfig = await getInvoiceTemplateConfig();
+
             expensesWithoutJustification.forEach((expense, index) => {
                 console.log(`⏱️ PDF GENERATION: Template ${index + 1}/${expensesWithoutJustification.length} - Dépense ID: ${expense.id}`);
                 if (!isFirstPage || index > 0) {
                     doc.addPage();
                 }
-                
-                // === EN-TÊTE MATA ===
-                doc.fontSize(24).font('Helvetica-Bold').fillColor('#1e3a8a').text('MATA', 50, 50);
-                
-                doc.fontSize(9).font('Helvetica').fillColor('black');
-                doc.text('Mirage, Apt Nord 603D, Résidence Aquanique', 50, 80);
-                doc.text('A : 01387695 2Y3 / RC : SN DKR 2024 B 29149', 50, 95);
-                doc.text('Ouest foire : 78 480 95 95', 50, 110);
-                doc.text('Grand Mbao / cité Aliou Sow : 77 858 96 96', 50, 125);
-                
+
+                // === EN-TÊTE FOURNISSEUR ===
+                // Plus de branding MATA (demande du compteable). Le helper
+                // affiche soit Nom/Lieu/Téléphone si on a un profil complet
+                // pour ce fournisseur, soit juste le nom en gras.
+                renderSupplierHeader(doc, expense.supplier, invoiceTemplateConfig);
+
                 doc.fontSize(16).font('Helvetica-Bold').fillColor('#1e3a8a').text('FACTURE', 275, 55);
                 
                 doc.fontSize(10).font('Helvetica').fillColor('black');
@@ -5123,31 +5578,12 @@ app.post('/api/expenses/generate-invoices-pdf', requireAuth, async (req, res) =>
                 doc.text(`${finalTotal} F`, 420, yPos + 8);
                 
                 yPos += 60;
-                
-                doc.fontSize(10).font('Helvetica').fillColor('black');
-                doc.text(`Dépense effectuée par : ${expense.user_name || expense.username}`, 50, yPos);
-                yPos += 15;
-                
-                if (expense.supplier) {
-                    doc.text(`Fournisseur : ${expense.supplier}`, 50, yPos);
-                    yPos += 15;
-                }
-                
-                // Cachet MATA
-            const cachetPath = path.join(__dirname, 'public', 'images', 'CachetMata.jpg');
-            if (fs.existsSync(cachetPath)) {
-                try {
-                        doc.image(cachetPath, 400, doc.page.height - 180, { width: 120, height: 120 });
-                } catch (error) {
-                        doc.fontSize(12).font('Helvetica-Bold').fillColor('#1e3a8a');
-                        doc.text('CACHET MATA', 450, doc.page.height - 100);
-                }
-                } else {
-                    doc.rect(400, doc.page.height - 180, 120, 120).stroke('#1e3a8a').lineWidth(2);
-                    doc.fontSize(10).font('Helvetica-Bold').fillColor('#1e3a8a');
-                    doc.text('CACHET\nMATA', 440, doc.page.height - 130, { align: 'center' });
-            }
-                
+
+                // NB : "Dépense effectuée par" + "Fournisseur :" + Cachet MATA
+                // ont été retirés (demande du compteable, nouveau format sans
+                // branding MATA). Le nom du fournisseur est déjà affiché en
+                // gras en haut de la facture.
+
                 isFirstPage = false;
         });
         
@@ -5400,21 +5836,18 @@ app.get('/api/expenses/generate-invoices-pdf-direct', requireAuth, async (req, r
             }
         }
         
-        // PARTIE 2: Ajouter les templates MATA complets
+        // PARTIE 2: Ajouter les templates de facture complets
+        // Charger la config (alias + profils fournisseurs) pour tout le batch.
+        const invoiceTemplateConfig = await getInvoiceTemplateConfig();
         expensesWithoutJustification.forEach((expense, index) => {
             if (!isFirstPage || index > 0) {
                 doc.addPage();
             }
-            
-            // === EN-TÊTE MATA ===
-            doc.fontSize(24).font('Helvetica-Bold').fillColor('#1e3a8a').text('MATA', 50, 50);
-            
-            doc.fontSize(9).font('Helvetica').fillColor('black');
-            doc.text('Mirage, Apt Nord 603D, Résidence Aquanique', 50, 80);
-            doc.text('A : 01387695 2Y3 / RC : SN DKR 2024 B 29149', 50, 95);
-            doc.text('Ouest foire : 78 480 95 95', 50, 110);
-            doc.text('Grand Mbao / cité Aliou Sow : 77 858 96 96', 50, 125);
-            
+
+            // === EN-TÊTE FOURNISSEUR ===
+            // Voir commentaire dans /api/expenses/generate-invoices-pdf.
+            renderSupplierHeader(doc, expense.supplier, invoiceTemplateConfig);
+
             doc.fontSize(16).font('Helvetica-Bold').fillColor('#1e3a8a').text('FACTURE', 275, 55);
             
             doc.fontSize(10).font('Helvetica').fillColor('black');
@@ -5485,31 +5918,11 @@ app.get('/api/expenses/generate-invoices-pdf-direct', requireAuth, async (req, r
             doc.text(`${finalTotal} F`, 420, yPos + 8);
             
             yPos += 60;
-            
-            doc.fontSize(10).font('Helvetica').fillColor('black');
-            doc.text(`Dépense effectuée par : ${expense.user_name || expense.username}`, 50, yPos);
-            yPos += 15;
-            
-            if (expense.supplier) {
-                doc.text(`Fournisseur : ${expense.supplier}`, 50, yPos);
-                yPos += 15;
-            }
-            
-            // Cachet MATA
-            const cachetPath = path.join(__dirname, 'public', 'images', 'CachetMata.jpg');
-            if (fs.existsSync(cachetPath)) {
-                try {
-                    doc.image(cachetPath, 400, doc.page.height - 180, { width: 120, height: 120 });
-                } catch (error) {
-                    doc.fontSize(12).font('Helvetica-Bold').fillColor('#1e3a8a');
-                    doc.text('CACHET MATA', 450, doc.page.height - 100);
-                }
-            } else {
-                doc.rect(400, doc.page.height - 180, 120, 120).stroke('#1e3a8a').lineWidth(2);
-                doc.fontSize(10).font('Helvetica-Bold').fillColor('#1e3a8a');
-                doc.text('CACHET\nMATA', 440, doc.page.height - 130, { align: 'center' });
-            }
-            
+
+            // NB : "Dépense effectuée par" + "Fournisseur :" + Cachet MATA
+            // ont été retirés (nouveau format sans branding MATA, demande du
+            // compteable). Le nom du fournisseur est en haut de la facture.
+
             isFirstPage = false;
         });
         
@@ -6878,6 +7291,670 @@ app.get('/api/partner/:accountId/deliveries', requireAuth, async (req, res) => {
 });
 
 
+// ============================================================
+// === MODÈLE DE FACTURE — alias + profils fournisseurs ===
+// ============================================================
+// Stocké dans app_settings (clés invoice_supplier_aliases et
+// invoice_supplier_profiles). Les valeurs DB écrasent les defaults
+// hardcodés (DEFAULT_SUPPLIER_ALIASES / DEFAULT_SUPPLIER_PROFILES).
+
+// GET : retourne la config courante (defaults + DB mergés)
+app.get('/api/invoice-template', requireAuth, async (req, res) => {
+    try {
+        const config = await getInvoiceTemplateConfig();
+        // On renvoie aussi les defaults pour que le front puisse indiquer
+        // "valeur par défaut" vs "personnalisée" si besoin.
+        res.json({
+            aliases: config.aliases,
+            profiles: config.profiles,
+            defaults: {
+                aliases: DEFAULT_SUPPLIER_ALIASES,
+                profiles: DEFAULT_SUPPLIER_PROFILES
+            }
+        });
+    } catch (error) {
+        console.error('Erreur GET /api/invoice-template:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// Helpers de validation pour PUT
+const INVOICE_TEMPLATE_MAX_KEYS = 200;     // anti-DoS
+const INVOICE_TEMPLATE_MAX_STRING_LEN = 255;
+function validateAliasMap(value) {
+    if (value === null || value === undefined) return { ok: true, value: {} };
+    if (typeof value !== 'object' || Array.isArray(value)) {
+        return { ok: false, error: 'aliases doit être un objet { alias_lowercase: forme_canonique }' };
+    }
+    const keys = Object.keys(value);
+    if (keys.length > INVOICE_TEMPLATE_MAX_KEYS) {
+        return { ok: false, error: `Trop d'alias (max ${INVOICE_TEMPLATE_MAX_KEYS})` };
+    }
+    const normalized = {};
+    for (const k of keys) {
+        const v = value[k];
+        if (typeof k !== 'string' || typeof v !== 'string') {
+            return { ok: false, error: 'Chaque alias doit être string -> string' };
+        }
+        if (k.length > INVOICE_TEMPLATE_MAX_STRING_LEN || v.length > INVOICE_TEMPLATE_MAX_STRING_LEN) {
+            return { ok: false, error: `Valeur d'alias trop longue (max ${INVOICE_TEMPLATE_MAX_STRING_LEN})` };
+        }
+        if (FORBIDDEN_CHARS_REGEX.test(k) || FORBIDDEN_CHARS_REGEX.test(v)) {
+            return { ok: false, error: 'Caractères interdits dans un alias' };
+        }
+        const trimmedKey = k.trim().toLowerCase().replace(/\s+/g, ' ');
+        const trimmedVal = v.trim();
+        if (!trimmedKey || !trimmedVal) continue; // on ignore les lignes vides
+        normalized[trimmedKey] = trimmedVal;
+    }
+    return { ok: true, value: normalized };
+}
+function validateProfileMap(value) {
+    if (value === null || value === undefined) return { ok: true, value: {} };
+    if (typeof value !== 'object' || Array.isArray(value)) {
+        return { ok: false, error: 'profiles doit être un objet { canonical_name: profile }' };
+    }
+    const keys = Object.keys(value);
+    if (keys.length > INVOICE_TEMPLATE_MAX_KEYS) {
+        return { ok: false, error: `Trop de profils (max ${INVOICE_TEMPLATE_MAX_KEYS})` };
+    }
+    const normalized = {};
+    for (const canonical of keys) {
+        const p = value[canonical];
+        if (typeof canonical !== 'string' || !canonical.trim()) continue;
+        if (!p || typeof p !== 'object' || Array.isArray(p)) {
+            return { ok: false, error: `Profil "${canonical}" invalide (doit être un objet)` };
+        }
+        const cleanCanonical = canonical.trim();
+        if (cleanCanonical.length > INVOICE_TEMPLATE_MAX_STRING_LEN || FORBIDDEN_CHARS_REGEX.test(cleanCanonical)) {
+            return { ok: false, error: `Nom canonique invalide pour profil "${canonical}"` };
+        }
+        const profile = {};
+        for (const field of ['displayName', 'location', 'phone']) {
+            const val = p[field];
+            if (val === undefined || val === null || val === '') continue;
+            if (typeof val !== 'string') {
+                return { ok: false, error: `Profil "${canonical}" : ${field} doit être une chaîne` };
+            }
+            if (val.length > INVOICE_TEMPLATE_MAX_STRING_LEN || FORBIDDEN_CHARS_REGEX.test(val)) {
+                return { ok: false, error: `Profil "${canonical}" : ${field} contient des caractères interdits ou est trop long` };
+            }
+            profile[field] = val.trim();
+        }
+        normalized[cleanCanonical] = profile;
+    }
+    return { ok: true, value: normalized };
+}
+
+// PUT : remplace la config (aliases + profils). Réservé aux super-admins
+// (admin / directeur_general / pca) — c'est un paramètre métier, pas
+// un paramètre système critique.
+app.put('/api/invoice-template', requireSuperAdmin, async (req, res) => {
+    try {
+        const aliasResult = validateAliasMap(req.body.aliases);
+        if (!aliasResult.ok) return res.status(400).json({ error: aliasResult.error });
+        const profileResult = validateProfileMap(req.body.profiles);
+        if (!profileResult.ok) return res.status(400).json({ error: profileResult.error });
+
+        const userId = req.session.user.id;
+        await pool.query(
+            `INSERT INTO app_settings (key, value, updated_by, updated_at)
+             VALUES ($1, $2::jsonb, $3, CURRENT_TIMESTAMP)
+             ON CONFLICT (key) DO UPDATE SET
+                 value = EXCLUDED.value,
+                 updated_at = CURRENT_TIMESTAMP,
+                 updated_by = EXCLUDED.updated_by`,
+            ['invoice_supplier_aliases', JSON.stringify(aliasResult.value), userId]
+        );
+        await pool.query(
+            `INSERT INTO app_settings (key, value, updated_by, updated_at)
+             VALUES ($1, $2::jsonb, $3, CURRENT_TIMESTAMP)
+             ON CONFLICT (key) DO UPDATE SET
+                 value = EXCLUDED.value,
+                 updated_at = CURRENT_TIMESTAMP,
+                 updated_by = EXCLUDED.updated_by`,
+            ['invoice_supplier_profiles', JSON.stringify(profileResult.value), userId]
+        );
+        invalidateInvoiceTemplateCache();
+        res.json({ ok: true, aliases: aliasResult.value, profiles: profileResult.value });
+    } catch (error) {
+        console.error('Erreur PUT /api/invoice-template:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// GET preview : génère un PDF d'exemple avec les valeurs courantes
+app.get('/api/invoice-template/preview', requireAuth, async (req, res) => {
+    try {
+        const supplier = (typeof req.query.supplier === 'string' ? req.query.supplier : '').trim() || 'Fournisseur DEMO';
+        if (supplier.length > INVOICE_TEMPLATE_MAX_STRING_LEN || FORBIDDEN_CHARS_REGEX.test(supplier)) {
+            return res.status(400).json({ error: 'Nom de fournisseur invalide' });
+        }
+        const config = await getInvoiceTemplateConfig();
+
+        const doc = new PDFDocument({ size: 'A4', margin: 0 });
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader('Content-Disposition', `inline; filename="apercu_facture.pdf"`);
+        res.setHeader('Cache-Control', 'no-cache');
+        doc.pipe(res);
+
+        // En-tête fournisseur (le coeur du template)
+        renderSupplierHeader(doc, supplier, config);
+        doc.fontSize(16).font('Helvetica-Bold').fillColor('#1e3a8a').text('FACTURE', 275, 55);
+        doc.fontSize(10).font('Helvetica').fillColor('black');
+        doc.text(`Date : ${new Date().toLocaleDateString('fr-FR')}`, 450, 50);
+        doc.fontSize(12).font('Helvetica-Bold').fillColor('#dc2626');
+        doc.text(`N° : 00000001`, 450, 70);
+
+        doc.moveTo(50, 160).lineTo(545, 160).stroke('#1e3a8a').lineWidth(1);
+
+        let yPos = 180;
+        doc.fontSize(14).font('Helvetica-Bold').fillColor('black');
+        doc.text('Dépenses (exemple)', 50, yPos);
+        yPos += 30;
+
+        // Mini-tableau d'exemple
+        const tableStartY = yPos;
+        const colPositions = [50, 110, 330, 430];
+        doc.rect(50, tableStartY, 495, 25).fill('#1e3a8a');
+        doc.fontSize(11).font('Helvetica-Bold').fillColor('white');
+        doc.text('QUANTITÉ', colPositions[0] + 5, tableStartY + 8);
+        doc.text('DÉSIGNATION', colPositions[1] + 5, tableStartY + 8);
+        doc.text('P. UNITAIRE', colPositions[2] + 5, tableStartY + 8);
+        doc.text('PRIX TOTAL', colPositions[3] + 5, tableStartY + 8);
+        yPos = tableStartY + 25;
+        doc.rect(50, yPos, 495, 30).fill('#f8f9fa').stroke('#dee2e6');
+        doc.fontSize(10).font('Helvetica').fillColor('black');
+        doc.text('1.00', colPositions[0] + 5, yPos + 10);
+        doc.text("Exemple d'article", colPositions[1] + 5, yPos + 10, { width: 200, height: 20 });
+        doc.text('100 000', colPositions[2] + 5, yPos + 10);
+        doc.text('100 000', colPositions[3] + 5, yPos + 10);
+        yPos += 30;
+        for (let i = 0; i < 3; i++) {
+            doc.rect(50, yPos, 495, 25).stroke('#dee2e6');
+            yPos += 25;
+        }
+        // Total
+        doc.rect(50, yPos, 495, 3).fill('#1e3a8a');
+        yPos += 10;
+        doc.rect(50, yPos, 360, 30).fill('#1e3a8a');
+        doc.fontSize(14).font('Helvetica-Bold').fillColor('white');
+        doc.text('MONTANT TOTAL', 60, yPos + 10);
+        doc.rect(410, yPos, 135, 30).stroke('#1e3a8a').lineWidth(2);
+        doc.fontSize(16).font('Helvetica-Bold').fillColor('#1e3a8a');
+        doc.text('100 000 F', 420, yPos + 8);
+
+        doc.end();
+    } catch (error) {
+        console.error('Erreur GET /api/invoice-template/preview:', error);
+        if (!res.headersSent) res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+
+// ============================================================
+// === TEMPLATE FACTURE CRÉANCE (ancien format MATA) ===
+// ============================================================
+// Config stockée dans app_settings (clé invoice_creance_template).
+// Sert pour les factures générées depuis Gestion Créance > Vue Globale
+// > Par client (un PDF par client ou un PDF batch tous clients).
+
+// GET : retourne la config courante (defaults + DB mergés)
+app.get('/api/invoice-creance-template', requireAuth, async (req, res) => {
+    try {
+        const config = await getCreanceInvoiceTemplate();
+        res.json({ ...config, defaults: DEFAULT_CREANCE_INVOICE_TEMPLATE });
+    } catch (error) {
+        console.error('Erreur GET /api/invoice-creance-template:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// Validation du payload PUT
+const CREANCE_TEMPLATE_FIELDS = [
+    'company_name', 'address_line_1', 'address_line_2',
+    'address_line_3', 'address_line_4', 'designation',
+    'categories', 'title_color'
+];
+// Champs structurels qu'on refuse de laisser vides : si l'utilisateur
+// saisit une chaîne vide, on retombe sur la valeur par défaut. Les
+// autres (lignes d'adresse, catégories) peuvent être effacés.
+const CREANCE_TEMPLATE_MANDATORY = ['company_name', 'designation', 'title_color'];
+function validateCreanceTemplate(body) {
+    if (!body || typeof body !== 'object') {
+        return { ok: false, error: 'Payload invalide' };
+    }
+    const normalized = {};
+    for (const f of CREANCE_TEMPLATE_FIELDS) {
+        const raw = body[f];
+        const mandatory = CREANCE_TEMPLATE_MANDATORY.includes(f);
+        if (raw === undefined || raw === null) {
+            // Pas fourni -> default
+            normalized[f] = DEFAULT_CREANCE_INVOICE_TEMPLATE[f];
+            continue;
+        }
+        if (typeof raw !== 'string') {
+            return { ok: false, error: `${f} doit être une chaîne` };
+        }
+        const v = raw.trim();
+        if (!v) {
+            // Vide explicite : autorisé pour les champs optionnels (efface),
+            // sinon on retombe sur le default.
+            normalized[f] = mandatory ? DEFAULT_CREANCE_INVOICE_TEMPLATE[f] : '';
+            continue;
+        }
+        if (v.length > INVOICE_TEMPLATE_MAX_STRING_LEN) {
+            return { ok: false, error: `${f} trop long (max ${INVOICE_TEMPLATE_MAX_STRING_LEN})` };
+        }
+        if (FORBIDDEN_CHARS_REGEX.test(v)) {
+            return { ok: false, error: `${f} contient des caractères interdits` };
+        }
+        normalized[f] = v;
+    }
+    // Validation explicite : couleur au format hex #RRGGBB
+    if (!/^#[0-9a-fA-F]{6}$/.test(normalized.title_color)) {
+        return { ok: false, error: 'title_color doit être une couleur hexadécimale #RRGGBB' };
+    }
+    return { ok: true, value: normalized };
+}
+
+// PUT : remplace la config. Réservé aux super-admins (admin/DG/PCA).
+app.put('/api/invoice-creance-template', requireSuperAdmin, async (req, res) => {
+    try {
+        const result = validateCreanceTemplate(req.body);
+        if (!result.ok) return res.status(400).json({ error: result.error });
+        const userId = req.session.user.id;
+        await pool.query(
+            `INSERT INTO app_settings (key, value, updated_by, updated_at)
+             VALUES ($1, $2::jsonb, $3, CURRENT_TIMESTAMP)
+             ON CONFLICT (key) DO UPDATE SET
+                 value = EXCLUDED.value,
+                 updated_at = CURRENT_TIMESTAMP,
+                 updated_by = EXCLUDED.updated_by`,
+            ['invoice_creance_template', JSON.stringify(result.value), userId]
+        );
+        invalidateCreanceInvoiceTemplateCache();
+        res.json({ ok: true, ...result.value });
+    } catch (error) {
+        console.error('Erreur PUT /api/invoice-creance-template:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// GET preview : PDF d'exemple avec un client fictif
+app.get('/api/invoice-creance-template/preview', requireAuth, async (req, res) => {
+    try {
+        const config = await getCreanceInvoiceTemplate();
+        const doc = new PDFDocument({ size: 'A4', margin: 0 });
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader('Content-Disposition', `inline; filename="apercu_facture_creance.pdf"`);
+        res.setHeader('Cache-Control', 'no-cache');
+        doc.pipe(res);
+        renderCreanceInvoice(doc, {
+            name: 'Maas Mbao',
+            portfolio: 'CREANCE_CDB',
+            solde: 757684
+        }, config, Date.now().toString());
+        doc.end();
+    } catch (error) {
+        console.error('Erreur preview facture creance:', error);
+        if (!res.headersSent) res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// =====================================================
+// GÉNÉRATION RÉELLE — Factures créance "par client"
+// =====================================================
+// GET /api/creance/global/invoice-pdf?date=YYYY-MM-DD
+//                                     &client_name=X        (optionnel : un seul client)
+//                                     &exclusionClients=A;B (optionnel : exclusions)
+// Sans client_name => batch tous clients de la vue (1 page par client).
+// Avec client_name => 1 PDF avec uniquement ce client (1 page).
+app.get('/api/creance/global/invoice-pdf', requireAuth, async (req, res) => {
+    try {
+        const dateInput = typeof req.query.date === 'string' && req.query.date.trim()
+            ? req.query.date.trim()
+            : new Date().toISOString().split('T')[0];
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(dateInput)) {
+            return res.status(400).json({ error: 'Paramètre date invalide (attendu YYYY-MM-DD)' });
+        }
+
+        const clientNameFilter = typeof req.query.client_name === 'string'
+            ? req.query.client_name.trim()
+            : '';
+        if (clientNameFilter && (clientNameFilter.length > 255 || FORBIDDEN_CHARS_REGEX.test(clientNameFilter))) {
+            return res.status(400).json({ error: 'client_name invalide' });
+        }
+
+        const MAX_CLIENT_EXCLUSIONS = 100;
+        const exclusionRaw = typeof req.query.exclusionClients === 'string' ? req.query.exclusionClients : '';
+        const exclusionList = exclusionRaw.split(';').map(s => s.trim()).filter(Boolean);
+        if (exclusionList.length > MAX_CLIENT_EXCLUSIONS) {
+            return res.status(400).json({ error: `Trop d'exclusions (max ${MAX_CLIENT_EXCLUSIONS})` });
+        }
+        for (const n of exclusionList) {
+            if (n.length > 255 || FORBIDDEN_CHARS_REGEX.test(n)) {
+                return res.status(400).json({ error: 'Nom d\'exclusion invalide' });
+            }
+        }
+        const exclusionLower = exclusionList.map(s => s.toLowerCase());
+
+        // Récup template
+        const tpl = await getCreanceInvoiceTemplate();
+
+        // Requête : pour chaque client créance, calculer le solde final
+        // au jour `dateInput` = initial_credit + credits<= - debits<=
+        const params = [dateInput, exclusionLower];
+        let clientFilterSql = '';
+        if (clientNameFilter) {
+            clientFilterSql = 'AND LOWER(cc.client_name) = LOWER($3)';
+            params.push(clientNameFilter);
+        }
+        const sql = `
+            SELECT
+                cc.client_name AS name,
+                a.account_name AS portfolio,
+                (cc.initial_credit
+                    + COALESCE(credits.total_credits, 0)
+                    - COALESCE(debits.total_debits, 0)) AS solde
+            FROM creance_clients cc
+            JOIN accounts a ON cc.account_id = a.id
+            LEFT JOIN (
+                SELECT client_id, SUM(amount) AS total_credits
+                FROM creance_operations
+                WHERE operation_type = 'credit' AND operation_date <= $1
+                GROUP BY client_id
+            ) credits ON cc.id = credits.client_id
+            LEFT JOIN (
+                SELECT client_id, SUM(amount) AS total_debits
+                FROM creance_operations
+                WHERE operation_type = 'debit' AND operation_date <= $1
+                GROUP BY client_id
+            ) debits ON cc.id = debits.client_id
+            WHERE a.account_type = 'creance'
+              AND a.is_active = true
+              AND cc.is_active = true
+              AND LOWER(cc.client_name) <> ALL($2::text[])
+              ${clientFilterSql}
+            ORDER BY solde DESC NULLS LAST, cc.client_name ASC
+        `;
+        const result = await pool.query(sql, params);
+        const clients = result.rows.map(r => ({
+            name: r.name,
+            portfolio: r.portfolio,
+            solde: parseFloat(r.solde || 0)
+        }));
+
+        if (clients.length === 0) {
+            return res.status(404).json({ error: 'Aucun client correspondant — aucune facture à générer' });
+        }
+
+        // Préparer le PDF
+        const doc = new PDFDocument({ size: 'A4', margin: 0 });
+        res.setHeader('Content-Type', 'application/pdf');
+        const safeName = clientNameFilter
+            ? clientNameFilter.replace(/[^a-zA-Z0-9]/g, '_')
+            : 'tous_clients';
+        const filename = `factures_creance_${safeName}_${dateInput.replace(/-/g, '')}.pdf`;
+        res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
+        res.setHeader('Cache-Control', 'no-cache');
+        doc.pipe(res);
+
+        // N° unique pour chaque page : Date.now() + index dans le batch.
+        // Garantit qu'aucun N° généré ne se retrouvera identique à un autre
+        // dans le même batch ET entre deux appels successifs (la base
+        // timestamp avance toujours).
+        const baseTimestamp = Date.now();
+        clients.forEach((client, index) => {
+            if (index > 0) doc.addPage();
+            const invoiceNumber = (baseTimestamp + index).toString();
+            renderCreanceInvoice(doc, client, tpl, invoiceNumber);
+        });
+
+        doc.end();
+    } catch (error) {
+        console.error('Erreur génération factures créance:', error);
+        if (!res.headersSent) res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+
+// ============================================================
+// === DOCUMENTS COMPTABLES (verrou par mot de passe partagé) ===
+// ============================================================
+
+// GET /api/comptable/status
+// Indique : si un mot de passe est configuré, si la session est actuellement
+// déverrouillée, et combien de temps il reste avant le re-prompt.
+app.get('/api/comptable/status', requireAuth, async (req, res) => {
+    try {
+        const hash = await getComptablePasswordHash();
+        const unlocked = isComptableUnlocked(req);
+        const expiresInMs = unlocked
+            ? Math.max(0, COMPTABLE_UNLOCK_TTL_MS - (Date.now() - req.session.comptableUnlockedAt))
+            : 0;
+        res.json({
+            password_set: !!hash,
+            unlocked,
+            expires_in_ms: expiresInMs,
+            ttl_ms: COMPTABLE_UNLOCK_TTL_MS
+        });
+    } catch (error) {
+        console.error('Erreur GET /api/comptable/status:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// POST /api/comptable/unlock { password }
+app.post('/api/comptable/unlock', requireAuth, async (req, res) => {
+    try {
+        const { password } = req.body || {};
+        if (typeof password !== 'string' || !password) {
+            return res.status(400).json({ error: 'Mot de passe requis' });
+        }
+        const hash = await getComptablePasswordHash();
+        if (!hash) {
+            return res.status(409).json({ error: 'Aucun mot de passe configuré — demandez à un administrateur de le définir', code: 'NO_PASSWORD_SET' });
+        }
+        const ok = await bcrypt.compare(password, hash);
+        if (!ok) {
+            return res.status(401).json({ error: 'Mot de passe incorrect' });
+        }
+        req.session.comptableUnlockedAt = Date.now();
+        res.json({ ok: true, expires_in_ms: COMPTABLE_UNLOCK_TTL_MS });
+    } catch (error) {
+        console.error('Erreur POST /api/comptable/unlock:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// POST /api/comptable/lock — verrou explicite (logout du module)
+app.post('/api/comptable/lock', requireAuth, (req, res) => {
+    if (req.session) delete req.session.comptableUnlockedAt;
+    res.json({ ok: true });
+});
+
+// PUT /api/comptable/password { newPassword, currentPassword? }
+// Définit ou change le mot de passe partagé. Super admin uniquement.
+// Si un mot de passe existe déjà, currentPassword est obligatoire (sauf pour
+// 'admin' strict qui peut forcer un reset).
+app.put('/api/comptable/password', requireSuperAdmin, async (req, res) => {
+    try {
+        const { newPassword, currentPassword } = req.body || {};
+        if (typeof newPassword !== 'string' || newPassword.length < 6) {
+            return res.status(400).json({ error: 'Le nouveau mot de passe doit faire au moins 6 caractères' });
+        }
+        if (newPassword.length > 200) {
+            return res.status(400).json({ error: 'Mot de passe trop long' });
+        }
+        const existingHash = await getComptablePasswordHash();
+        if (existingHash) {
+            const isAdminStrict = req.session.user && req.session.user.role === 'admin';
+            if (!isAdminStrict) {
+                if (typeof currentPassword !== 'string' || !currentPassword) {
+                    return res.status(400).json({ error: 'Mot de passe actuel requis pour le changement' });
+                }
+                const okCurrent = await bcrypt.compare(currentPassword, existingHash);
+                if (!okCurrent) {
+                    return res.status(401).json({ error: 'Mot de passe actuel incorrect' });
+                }
+            }
+        }
+        const newHash = await bcrypt.hash(newPassword, 10);
+        const userId = req.session.user.id;
+        await pool.query(
+            `INSERT INTO app_settings (key, value, updated_by, updated_at)
+             VALUES ($1, $2::jsonb, $3, CURRENT_TIMESTAMP)
+             ON CONFLICT (key) DO UPDATE SET
+                 value = EXCLUDED.value,
+                 updated_at = CURRENT_TIMESTAMP,
+                 updated_by = EXCLUDED.updated_by`,
+            [COMPTABLE_PASSWORD_SETTING_KEY, JSON.stringify({ hash: newHash }), userId]
+        );
+        // Invalide les sessions courantes pour forcer un nouveau unlock
+        if (req.session) delete req.session.comptableUnlockedAt;
+        res.json({ ok: true });
+    } catch (error) {
+        console.error('Erreur PUT /api/comptable/password:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// GET /api/comptable/documents?year=2026
+app.get('/api/comptable/documents', requireComptableUnlock, async (req, res) => {
+    try {
+        const year = parseInt(req.query.year, 10);
+        if (!year || year < 2000 || year > 2100) {
+            return res.status(400).json({ error: 'Paramètre year invalide' });
+        }
+        const r = await pool.query(
+            `SELECT d.id, d.libelle, d.year, d.original_filename, d.mime_type,
+                    d.size_bytes, d.uploaded_at, u.full_name AS uploaded_by_name
+             FROM comptable_documents d
+             LEFT JOIN users u ON d.uploaded_by = u.id
+             WHERE d.year = $1
+             ORDER BY d.uploaded_at DESC`,
+            [year]
+        );
+        res.json(r.rows);
+    } catch (error) {
+        if (error.code === PG_UNDEFINED_TABLE) {
+            return res.status(503).json({ error: 'Table comptable_documents absente — exécutez la migration' });
+        }
+        console.error('Erreur GET /api/comptable/documents:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// POST /api/comptable/documents (multipart : file + libelle + year)
+app.post('/api/comptable/documents',
+    requireComptableUnlock,
+    comptableUpload.single('file'),
+    async (req, res) => {
+        try {
+            if (!req.file) {
+                return res.status(400).json({ error: 'Aucun fichier reçu' });
+            }
+            const libelle = typeof req.body.libelle === 'string' ? req.body.libelle.trim() : '';
+            const year = parseInt(req.body.year, 10);
+            if (!libelle) {
+                // Nettoyer le fichier orphelin
+                try { fs.unlinkSync(req.file.path); } catch (_) {}
+                return res.status(400).json({ error: 'Libellé requis' });
+            }
+            if (libelle.length > 255 || FORBIDDEN_CHARS_REGEX.test(libelle)) {
+                try { fs.unlinkSync(req.file.path); } catch (_) {}
+                return res.status(400).json({ error: 'Libellé invalide (trop long ou caractères interdits)' });
+            }
+            if (!year || year < 2000 || year > 2100) {
+                try { fs.unlinkSync(req.file.path); } catch (_) {}
+                return res.status(400).json({ error: 'Année invalide' });
+            }
+            const userId = req.session.user.id;
+            const ins = await pool.query(
+                `INSERT INTO comptable_documents
+                    (libelle, year, original_filename, stored_path, mime_type, size_bytes, uploaded_by)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 RETURNING id, libelle, year, original_filename, mime_type, size_bytes, uploaded_at`,
+                [libelle, year, req.file.originalname, req.file.path, req.file.mimetype, req.file.size, userId]
+            );
+            res.status(201).json(ins.rows[0]);
+        } catch (error) {
+            // Cleanup fichier en cas d'erreur SQL
+            if (req.file && req.file.path) {
+                try { fs.unlinkSync(req.file.path); } catch (_) {}
+            }
+            if (error.code === PG_UNDEFINED_TABLE) {
+                return res.status(503).json({ error: 'Table comptable_documents absente — exécutez la migration' });
+            }
+            console.error('Erreur POST /api/comptable/documents:', error);
+            res.status(500).json({ error: 'Erreur serveur' });
+        }
+    }
+);
+
+// GET /api/comptable/documents/:id/download
+app.get('/api/comptable/documents/:id/download', requireComptableUnlock, async (req, res) => {
+    try {
+        const id = parseInt(req.params.id, 10);
+        if (!id) return res.status(400).json({ error: 'ID invalide' });
+        const r = await pool.query(
+            'SELECT stored_path, original_filename, mime_type FROM comptable_documents WHERE id = $1',
+            [id]
+        );
+        if (r.rows.length === 0) return res.status(404).json({ error: 'Document introuvable' });
+        const doc = r.rows[0];
+        if (!fs.existsSync(doc.stored_path)) {
+            return res.status(410).json({ error: 'Fichier physique introuvable sur le serveur' });
+        }
+        // Servir en inline pour les PDF/images, en download pour le reste
+        const inlineMimes = ['application/pdf', 'image/jpeg', 'image/png'];
+        const disposition = inlineMimes.includes(doc.mime_type) ? 'inline' : 'attachment';
+        const filename = doc.original_filename || ('document_' + id);
+        res.setHeader('Content-Type', doc.mime_type || 'application/octet-stream');
+        res.setHeader('Content-Disposition', `${disposition}; filename="${filename.replace(/"/g, '')}"`);
+        fs.createReadStream(doc.stored_path).pipe(res);
+    } catch (error) {
+        console.error('Erreur download document comptable:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+// DELETE /api/comptable/documents/:id  body: { password }
+// La suppression demande de re-saisir le mot de passe (sécurité supplémentaire).
+app.delete('/api/comptable/documents/:id', requireComptableUnlock, async (req, res) => {
+    try {
+        const id = parseInt(req.params.id, 10);
+        if (!id) return res.status(400).json({ error: 'ID invalide' });
+        const { password } = req.body || {};
+        if (typeof password !== 'string' || !password) {
+            return res.status(400).json({ error: 'Mot de passe requis pour la suppression' });
+        }
+        const hash = await getComptablePasswordHash();
+        if (!hash) {
+            return res.status(409).json({ error: 'Aucun mot de passe configuré' });
+        }
+        const ok = await bcrypt.compare(password, hash);
+        if (!ok) return res.status(401).json({ error: 'Mot de passe incorrect' });
+
+        const r = await pool.query(
+            'SELECT stored_path FROM comptable_documents WHERE id = $1',
+            [id]
+        );
+        if (r.rows.length === 0) return res.status(404).json({ error: 'Document introuvable' });
+        const storedPath = r.rows[0].stored_path;
+        await pool.query('DELETE FROM comptable_documents WHERE id = $1', [id]);
+        // Best-effort suppression du fichier physique
+        try { if (storedPath && fs.existsSync(storedPath)) fs.unlinkSync(storedPath); }
+        catch (e) { console.warn('Suppression fichier comptable échouée :', e.message); }
+        res.json({ ok: true });
+    } catch (error) {
+        console.error('Erreur DELETE /api/comptable/documents:', error);
+        res.status(500).json({ error: 'Erreur serveur' });
+    }
+});
+
+
 // === ROUTES POUR LA G+�N+�RATION DE FACTURES PARTENAIRES ===
 // IMPORTANT: Ces routes doivent +�tre AVANT les routes g+�n+�rales avec :deliveryId
 
@@ -6997,15 +8074,13 @@ app.get('/api/partner/generate-invoice-pdf-direct', requireAuth, async (req, res
         
         doc.pipe(res);
         
-        // === EN-T+�TE MATA (identique au template existant) ===
-        doc.fontSize(24).font('Helvetica-Bold').fillColor('#1e3a8a').text('MATA', 50, 50);
-        
-        doc.fontSize(9).font('Helvetica').fillColor('black');
-        doc.text('Mirage, Apt Nord 603D, Residence Aquanique', 50, 80);
-        doc.text('A : 01387695 2Y3 / RC : SN DKR 2024 B 29149', 50, 95);
-        doc.text('Ouest foire : 78 480 95 95', 50, 110);
-        doc.text('Grand Mbao / cite Aliou Sow : 77 858 96 96', 50, 125);
-        
+        // === EN-TETE FOURNISSEUR / PARTENAIRE ===
+        // Nouveau format sans branding MATA (demande du compteable).
+        // Le bloc "PARTENAIRE : ..." plus bas devient redondant mais on
+        // le garde pour ne pas perturber la lecture comptable existante.
+        const invoiceTemplateConfig = await getInvoiceTemplateConfig();
+        renderSupplierHeader(doc, partner_name, invoiceTemplateConfig);
+
         doc.fontSize(16).font('Helvetica-Bold').fillColor('#1e3a8a').text('FACTURE', 275, 55);
         
         doc.fontSize(10).font('Helvetica').fillColor('black');
@@ -13482,13 +14557,10 @@ app.put('/api/creance/:accountId/clients/:clientId', requireAdminAuth, async (re
     }
 });
 
-// Middleware pour vérifier les permissions admin strictes (admin seulement)
-const requireStrictAdminAuth = (req, res, next) => {
-    if (!req.session?.user || req.session.user.role !== 'admin') {
-        return res.status(403).json({ error: 'Accès refusé - Seul l\'admin peut effectuer cette action' });
-    }
-    next();
-};
+// Le middleware requireStrictAdminAuth est désormais déclaré plus haut
+// dans le fichier (à côté de requireAuth / requireAdminAuth) pour éviter
+// un ReferenceError TDZ : certaines routes l'utilisent avant la position
+// historique de cette déclaration.
 
 // Route pour supprimer un client créance (Admin seulement)
 app.delete('/api/creance/:accountId/clients/:clientId', requireStrictAdminAuth, async (req, res) => {


### PR DESCRIPTION
The TYPE column now renders a green "↑ Avance" pill or a red "↓ Remboursement" pill instead of plain bold text. The MONTANT column is colored green / red with an explicit + / − sign prefix. Each row gets a thin colored left border (green for credit, red for debit) for a quick at-a-glance scan. Dark-mode variants use lighter green/red so the colors stay readable on the dark surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-client invoice PDF generation from the UI and bulk invoice export.
  * Admin "Invoice template" and legacy "Facture CRÉANCE" editors with live preview and save/reload.
  * "Documents comptables" panel with password-protected unlock, upload, year-filtered listing, download and delete.
  * Operation rows show explicit type pills and signed (+/−) amounts with formatted currency.

* **Style**
  * New styling for operation pills, signed amounts, invoice preview cards, accounting upload/list views and dark-mode support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zalint/MATA_DEPENSES_MANAGEMENT/pull/40)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->