### PR TITLE
remove "Dépenses" title from créance invoice

### DIFF
--- a/server.js
+++ b/server.js
@@ -250,11 +250,9 @@ function renderCreanceInvoice(doc, clientData, tpl, invoiceNumber) {
     doc.strokeColor(color).lineWidth(1);
     doc.moveTo(50, 160).lineTo(545, 160).stroke();
 
-    // Titre de section
-    let yPos = 180;
-    doc.fontSize(14).font('Helvetica-Bold').fillColor('black');
-    doc.text('Dépenses', 50, yPos);
-    yPos += 30;
+    // Pas de titre "Dépenses" sur la facture créance (demande client) —
+    // on enchaîne directement avec le tableau après un petit espace.
+    let yPos = 185;
 
     // En-tête du tableau
     const tableStartY = yPos;


### PR DESCRIPTION
Per accountant request the section title above the table is dropped on créance factures only — the table follows the header separator directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "Dépenses" section title from invoice rendering
  * Optimized table layout positioning and spacing for improved invoice document presentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zalint/MATA_DEPENSES_MANAGEMENT/pull/41)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->